### PR TITLE
ENH+RF: Drop id_column argument, support multi-column id

### DIFF
--- a/test_pyout.py
+++ b/test_pyout.py
@@ -136,31 +136,11 @@ def test_tabular_write_update():
     for row in data:
         out(row)
 
-    out.rewrite("foo", "status", "installed",
+    out.rewrite({"name": "foo"}, "status", "installed",
                 style = {"name": {"width": 3},
                          "status": {"width": 9}})
 
     expected = unicode_cap("cuu1") * 2 + unicode_cap("el") + "foo installed"
-    assert eq_repr(fd.getvalue().strip().splitlines()[-1],
-                   expected)
-
-
-@patch("pyout.Terminal", TestTerminal)
-def test_tabular_write_update_nondefault_id():
-    fd = StringIO()
-    out = Tabular(["name", "id", "status"], id_column="id",
-                  stream=fd, force_styling=True)
-    data = [{"name": "foo", "id": "0", "status": "unknown"},
-            {"name": "bar", "id": "1", "status": "installed"}]
-    for row in data:
-        out(row)
-
-    out.rewrite("0", "status", "installed",
-                style = {"name": {"width": 3},
-                         "id": {"width": 1},
-                         "status": {"width": 9}})
-
-    expected = unicode_cap("cuu1") * 2 + unicode_cap("el") + "foo 0 installed"
     assert eq_repr(fd.getvalue().strip().splitlines()[-1],
                    expected)
 
@@ -176,9 +156,31 @@ def test_tabular_write_update_notfound():
         out(row)
 
     with pytest.raises(ValueError):
-        out.rewrite("not here", "status", "installed",
+        out.rewrite({"name": "not here"}, "status", "installed",
                     style = {"name": {"width": 3},
                              "status": {"width": 9}})
+
+
+@patch("pyout.Terminal", TestTerminal)
+def test_tabular_write_update_multi_id():
+    fd = StringIO()
+    out = Tabular(["name", "type", "status"],
+                  stream=fd, force_styling=True)
+    data = [{"name": "foo", "type": "0", "status": "unknown"},
+            {"name": "foo", "type": "1", "status": "unknown"},
+            {"name": "bar", "type": "2", "status": "installed"}]
+    for row in data:
+        out(row)
+
+    out.rewrite({"name": "foo", "type": "0"},
+                "status", "installed",
+                style = {"name": {"width": 3},
+                         "type": {"width": 1},
+                         "status": {"width": 9}})
+
+    expected = unicode_cap("cuu1") * 3 + unicode_cap("el") + "foo 0 installed"
+    assert eq_repr(fd.getvalue().strip().splitlines()[-1],
+                   expected)
 
 
 @patch("pyout.Terminal", TestTerminal)


### PR DESCRIPTION
```
Make Tabular.rewrite take a dictionary with {column: value, ...} to
identify the row to rewrite.  This way, we don't force the caller
specify the id column at instance creation.  Also, we can easily
support a multi-column id without having to worry about making
__init__'s id_column and rewrite's ids take both single and
multi-value forms.

The tradeoff is that the rewrite call is a little more verbose for
simple cases, but the intention should also be clearer (the
column->value mapping is right there so you don't have to think "oh
yeah, that first value is a value for id column").
```

Follow up to https://github.com/pyout/pyout/pull/14#discussion_r158509081