### PR TITLE
setup.py (classifiers): Specify POSIX for OS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "Environment :: Console",
         "Development Status :: 1 - Planning",
         "Topic :: Utilities",
+        "Operating System :: POSIX",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
... since pyout will currently fail on Windows.

Re: #4, #13, #27