### PR TITLE
ENH: Support transform function (e.g., humanize.naturalsize) via style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ TODO Summary
 
 ### Added
 
-- A new style type, "transform", has been added to the schema.
+- A new style attribute, "transform", has been added to the schema.
 
-  This type can be used to provide a function that takes a field value
-  and returns a transformed field value.
+  This feature can be used to provide a function that takes a field
+  value and returns a transformed field value.
 
 ### Changed
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 TODO Summary
 
 ### Added
+
+- A new style type, "transform", has been added to the schema.
+
+  This type can be used to provide a function that takes a field value
+  and returns a transformed field value.
+
 ### Changed
 ### Deprecated
 ### Fixed

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -52,6 +52,7 @@ schema = {
             "properties": {"align": {"$ref": "#/definitions/align"},
                            "bold": {"$ref": "#/definitions/bold"},
                            "color": {"$ref": "#/definitions/color"},
+                           "transform": {"$ref": "#/definitions/transform"},
                            "underline": {"$ref": "#/definitions/underline"},
                            "width": {"$ref": "#/definitions/width"}},
             "additionalProperties": False},
@@ -72,7 +73,14 @@ schema = {
             "description": "Map a value to a style",
             "type": "object",
             "properties": {"label": {"type": "object"}},
-            "additionalProperties": False}
+            "additionalProperties": False},
+        "transform": {
+            "description": """An arbitrary function.
+            This function will be called with the (unprocessed) field
+            value as the single argument and should return a
+            transformed value.  Note: This function should not have
+            side-effects because it may be called multiple times.""",
+            "scope": "field"}
     },
     "type": "object",
     "properties": {

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -11,7 +11,7 @@ schema = {
             "type": "string",
             "enum": ["left", "right", "center"],
             "default": "left",
-            "scope": "table"},
+            "scope": "column"},
         "bold": {
             "description": "Whether text is bold",
             "oneOf": [{"type": "boolean"},
@@ -46,7 +46,7 @@ schema = {
                            "max": {"type": ["integer", "null"]},
                            "min": {"type": ["integer", "null"]}}}],
             "default": "auto",
-            "scope": "table"},
+            "scope": "column"},
         "styles": {
             "type": "object",
             "properties": {"align": {"$ref": "#/definitions/align"},

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -30,8 +30,12 @@ class Field(object):
     ----------
     width : int
     align : str
-    pre, post : dict
-        Each key maps to a list of processors.
+    pre, post : dict of lists
+        Each key maps to a list of processors.  Conceptually, `pre`
+        and `post` are a list of functions that form a pipeline, but
+        they are structured as a dict of lists to allow different
+        processors to be grouped by key.  By specifying keys, the
+        caller can control which groups are "enabled".
     pre_keys, post_keys : list
         These lists define which processor lists are called by default
         and in what order.  The values can be overridden by the

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -81,8 +81,7 @@ class Field(object):
             keys.append(key)
         if key not in procs:
             procs[key] = []
-        for value in values:
-            procs[key].append(value)
+        procs[key].extend(values)
 
     @property
     def width(self):

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -3,7 +3,7 @@
 
 
 class Field(object):
-    """Format, process, and render tabular fields.
+    """Render values based on a list of processors.
 
     A Field instance is a template for a string that is defined by its
     width, text alignment, and its "processors".  When a field is

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -29,7 +29,6 @@ class Field(object):
     Attributes
     ----------
     width : int
-    align : str
     pre, post : dict of lists
         Each key maps to a list of processors.  Conceptually, `pre`
         and `post` are a list of functions that form a pipeline, but

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -33,9 +33,9 @@ class Field(object):
     pre, post : dict
         Each key maps to a list of processors.
     pre_keys, post_keys : list
-        These lists define with processor lists are called by default
+        These lists define which processor lists are called by default
         and in what order.  The values can be overridden by the
-        providign `pre_keys` and `post_keys` arguments when calling
+        providing `pre_keys` and `post_keys` arguments when calling
         the instance.
     """
 

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -23,8 +23,8 @@ class Field(object):
 
     Parameters
     ----------
-    width : int
-    align : {'left', 'right', 'center'}
+    width : int, optional
+    align : {'left', 'right', 'center'}, optional
 
     Attributes
     ----------

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -127,6 +127,15 @@ class Field(object):
         return result
 
 
+class StyleFunctionError(Exception):
+    """Signal that a style function failed.
+    """
+    def __init__(self, function):
+        msg = ("Style transform {} raised an exception. "
+               "See above.".format(function))
+        super(StyleFunctionError, self).__init__(msg)
+
+
 class StyleProcessors(object):
     """A base class for generating Field.processors for styled output.
 
@@ -191,6 +200,17 @@ class StyleProcessors(object):
                     return result[:marker_beg] + marker
             return result[:length]
         return truncate_fn
+
+    @staticmethod
+    def transform(function):
+        """Return a processor for a style's "transform" function.
+        """
+        def transform_fn(_, result):
+            try:
+                return function(result)
+            except:
+                raise StyleFunctionError(function)
+        return transform_fn
 
     def by_key(self, key):
         """Return a processor for the style given by `key`.
@@ -301,8 +321,8 @@ class StyleProcessors(object):
         -------
         A generator object.
         """
-        return
-        yield
+        if "transform" in column_style:
+            yield self.transform(column_style["transform"])
 
     def post_from_style(self, column_style):
         """Yield post-format processors based on `column_style`.

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -107,9 +107,11 @@ class Field(object):
         Parameters
         ----------
         value : str
-        which : str, optional
-            A key for the `processors` attribute that indicates the
-            list of processors to use in addition to the "core" list.
+        pre_keys, post_keys : sequence, optional
+            These lists define which processor lists are called and in
+            what order.  If not specified, the keys defined by the
+            corresponding attribute (`pre_keys` or `post_keys`) will
+            be used.
         """
         if pre_keys is None:
             pre_keys = self.pre_keys

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -248,12 +248,13 @@ class Tabular(object):
         rewrite = False
         for column in self._columns:
             if column in self._autowidth_columns:
+                field = self._fields[column]
                 value_width = len(str(row[column]))
                 wmax = self._autowidth_columns[column]["max"]
-                if value_width > self._fields[column].width:
-                    if wmax is None or self._fields[column].width < wmax:
+                if value_width > field.width:
+                    if wmax is None or field.width < wmax:
                         rewrite = True
-                    self._fields[column].width = value_width
+                    field.width = value_width
         if rewrite:
             raise RewritePrevious
 

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -339,7 +339,7 @@ class Tabular(object):
         style : dict or None
             Overridding style or None.
         adopt : bool, optional
-            If true, use overalp `style` on top of `self._style`.
+            If true, overlay `style` on top of `self._style`.
             Otherwise, treat `style` as a standalone style.
         repaint : bool, optional
             Whether to repaint of width check reports that previous

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -301,7 +301,7 @@ class Tabular(object):
                 self._lock.release()
 
     def _style_proc_group(self, style, adopt=True):
-        """Return whether group is "default" or "overrriding".
+        """Return whether group is "default" or "override".
 
         In the case of "override", the self._fields pre-format and
         post-format processors will be set under the "override" key.

--- a/pyout/tests/test_field.py
+++ b/pyout/tests/test_field.py
@@ -15,17 +15,22 @@ def test_field_update():
 
 
 def test_field_processors():
-    field = Field(width=6, align="center")
+    def pre(_, result):
+        return result.upper()
 
-    def proc1(_, result):
+    def post1(_, result):
         return "AAA" + result
 
-    def proc2(_, result):
+    def post2(_, result):
         return result + "ZZZ"
 
-    field.processors["default"] = [proc1, proc2]
+    field = Field(width=6, align="center")
+    field.add("pre", "some_key", pre)
+    field.add("post", "another_key", *[post1, post2])
+    assert field("ok") == "AAA  OK  ZZZ"
 
-    assert field("ok") == "AAA  ok  ZZZ"
+    with pytest.raises(ValueError):
+        field.add("not pre or post", "k")
 
 
 def test_truncate_mark_true():

--- a/pyout/tests/test_field.py
+++ b/pyout/tests/test_field.py
@@ -24,13 +24,17 @@ def test_field_processors():
     def post2(_, result):
         return result + "ZZZ"
 
-    field = Field(width=6, align="center")
+    field = Field(width=6, align="center",
+                  default_keys=["some_key", "another_key"])
     field.add("pre", "some_key", pre)
     field.add("post", "another_key", *[post1, post2])
     assert field("ok") == "AAA  OK  ZZZ"
 
     with pytest.raises(ValueError):
         field.add("not pre or post", "k")
+
+    with pytest.raises(ValueError):
+        field.add("pre", "not registered key")
 
 
 def test_truncate_mark_true():

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -634,6 +634,21 @@ def test_tabular_write_transform_with_header():
 
 
 @patch("pyout.tabular.Terminal", TestTerminal)
+def test_tabular_write_transform_autowidth():
+    fd = StringIO()
+    out = Tabular(style={"val": {"transform": lambda x: x * 2}},
+                  stream=fd)
+    out(OrderedDict([("name", "foo"),
+                     ("val", "330")]))
+    out(OrderedDict([("name", "bar"),
+                     ("val", "7800")]))
+
+    lines = fd.getvalue().splitlines()
+    assert len([ln for ln in lines if ln.endswith("foo 330330  ")]) == 1
+    assert len([ln for ln in lines if ln.endswith("bar 78007800")]) == 1
+
+
+@patch("pyout.tabular.Terminal", TestTerminal)
 def test_tabular_write_transform_on_header():
     fd = StringIO()
     out = Tabular(style={"header_": {"transform": str.upper},

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -9,6 +9,7 @@ from mock import patch
 import pytest
 
 from pyout import Tabular
+from pyout.field import StyleFunctionError
 
 # TestTerminal, unicode_cap, and unicode_parm are copied from
 # blessings' tests.
@@ -597,6 +598,70 @@ def test_tabular_write_intervals_bold():
                "78" + unicode_cap("sgr0") + "\n" + \
                "bar 33\n"
     assert eq_repr(fd.getvalue(), expected)
+
+
+@patch("pyout.tabular.Terminal", TestTerminal)
+def test_tabular_write_transform():
+    fd = StringIO()
+    out = Tabular(style={"val": {"transform": lambda x: x[::-1]}},
+                  stream=fd)
+    out(OrderedDict([("name", "foo"),
+                     ("val", "330")]))
+    out(OrderedDict([("name", "bar"),
+                     ("val", "780")]))
+
+    expected = ("foo 033\n"
+                "bar 087\n")
+    assert eq_repr(fd.getvalue(), expected)
+
+
+@patch("pyout.tabular.Terminal", TestTerminal)
+def test_tabular_write_transform_with_header():
+    fd = StringIO()
+    out = Tabular(style={"header_": {},
+                         "name": {"width": 4},
+                         "val": {"transform": lambda x: x[::-1]}},
+                  stream=fd)
+    out(OrderedDict([("name", "foo"),
+                     ("val", "330")]))
+    out(OrderedDict([("name", "bar"),
+                     ("val", "780")]))
+
+    expected = ("name val\n"
+                "foo  033\n"
+                "bar  087\n")
+    assert eq_repr(fd.getvalue(), expected)
+
+
+@patch("pyout.tabular.Terminal", TestTerminal)
+def test_tabular_write_transform_on_header():
+    fd = StringIO()
+    out = Tabular(style={"header_": {"transform": str.upper},
+                         "name": {"width": 4},
+                         "val": {"width": 3}},
+                  stream=fd)
+    out(OrderedDict([("name", "foo"),
+                     ("val", "330")]))
+    out(OrderedDict([("name", "bar"),
+                     ("val", "780")]))
+
+    expected = ("NAME VAL\n"
+                "foo  330\n"
+                "bar  780\n")
+    assert eq_repr(fd.getvalue(), expected)
+
+
+@patch("pyout.tabular.Terminal", TestTerminal)
+def test_tabular_write_transform_func_error():
+    fd = StringIO()
+    out = Tabular(style={"name": {"width": 4},
+                         "val": {"transform": lambda x: x[::-1]}},
+                  stream=fd)
+    # The transform function receives the data as given, so it fails
+    # trying to index an integer.
+    with pytest.raises(StyleFunctionError):
+        out(OrderedDict([("name", "foo"),
+                         ("val", 330)]))
 
 
 @patch("pyout.tabular.Terminal", TestTerminal)


### PR DESCRIPTION
You can now add a style entry in the form of
`"<column>": {"transform": <function>}`, where `function` takes a
single argument and returns a transformed value.

As an example,

```
from pyout import Tabular
from humanize import naturalsize

out = Tabular(columns=["name", "size", "path"],
              style={
                  "header_": {"transform": str.upper},
                  "separator_": " | ",
                  "size": {"transform": naturalsize,
                           "color": {"interval": [[5000, None, "red"]]}}})

out({"name": "x", "size": 3, "path": "/tmp/x"})
out({"name": "y", "size": 3000, "path": "/tmp/y"})
out({"name": "z", "size": 300000000, "path": "/tmp/z"})
```

outputs

```
NAME | SIZE     | PATH
x    | 3 Bytes  | /tmp/x
y    | 3.0 kB   | /tmp/y
z    | 300.0 MB | /tmp/z
```

(with the last size field in red)

Closes #23.
