### PR TITLE
ENH: tabular: Don't require initial values for callables

### DIFF
--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -129,7 +129,7 @@ class Tabular(object):
         self._columns = columns
         self._ids = None
         self._fields = None
-        self._transform_method = None
+        self._normalizer = None
 
         self._init_style = style
         self._style = None
@@ -236,7 +236,7 @@ class Tabular(object):
     def _attrs_to_dict(self, row):
         return {c: getattr(row, c) for c in self._columns}
 
-    def _choose_transform_method(self, row):
+    def _choose_normalizer(self, row):
         if isinstance(row, Mapping):
             return self._identity
         if isinstance(row, Sequence):
@@ -379,8 +379,8 @@ class Tabular(object):
 
         if isinstance(self._columns, OrderedDict):
             row = self._columns
-        elif self._transform_method == self._seq_to_dict:
-            row = self._transform_method(self._columns)
+        elif self._normalizer == self._seq_to_dict:
+            row = self._normalizer(self._columns)
         else:
             row = dict(zip(self._columns, self._columns))
 
@@ -503,9 +503,9 @@ class Tabular(object):
             self._setup_style()
             self._setup_fields()
 
-        if self._transform_method is None:
-            self._transform_method = self._choose_transform_method(row)
-        row = self._transform_method(row)
+        if self._normalizer is None:
+            self._normalizer = self._choose_normalizer(row)
+        row = self._normalizer(row)
         callables = self._strip_callables(row)
 
         with self._write_lock():

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -873,11 +873,12 @@ def test_tabular_write_callable_values():
     with Tabular(["name", "status"], stream=fd, force_styling=True) as out:
         out({"name": "foo", "status": ("thinking", delay0.run)})
         out({"name": "bar", "status": "ok"})
-        out({"name": "baz", "status": ("waiting", delay1.run)})
+        # A single callable can be passed rather than (initial_value, fn).
+        out({"name": "baz", "status": delay1.run})
 
         expected = ("foo thinking\n"
                     "bar ok      \n"
-                    "baz waiting \n")
+                    "baz         \n")
         assert eq_repr(fd.getvalue(), expected)
 
         delay0.now = True


### PR DESCRIPTION
This makes it easier to use callable when the data accessed via an
objects attributes, though this still won't work well with properties.
We might want to export a style key like "initial value" so that the
user can specify something other than an empty string.