### PR TITLE
Allow incomplete records

### DIFF
--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -28,6 +28,12 @@ schema = {
                       {"$ref": "#/definitions/interval"}],
             "default": "black",
             "scope": "field"},
+        "missing": {
+            "description": "Text to display for missing values",
+            "type": "string",
+            "default": "",
+            "scope": "column"
+        },
         "underline": {
             "description": "Whether text is underlined",
             "oneOf": [{"type": "boolean"},
@@ -52,6 +58,7 @@ schema = {
             "properties": {"align": {"$ref": "#/definitions/align"},
                            "bold": {"$ref": "#/definitions/bold"},
                            "color": {"$ref": "#/definitions/color"},
+                           "missing": {"$ref": "#/definitions/missing"},
                            "transform": {"$ref": "#/definitions/transform"},
                            "underline": {"$ref": "#/definitions/underline"},
                            "width": {"$ref": "#/definitions/width"}},

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -150,12 +150,21 @@ class Nothing(object):
 
     This is used instead of a built-ins like None, "", or 0 to allow
     us to unambiguously identify a missing value.  In terms of
-    methods, it tries to mimic an empty string because that behavior
-    is the most useful internally for formatting the output.
+    methods, it tries to mimic the string `text` (an empty string by
+    default) because that behavior is the most useful internally for
+    formatting the output.
+
+    Parameters
+    ----------
+    text : str, optional
+        Text to use for string representation of this object.
     """
 
+    def __init__(self, text=""):
+        self._text = text
+
     def __str__(self):
-        return ""
+        return self._text
 
     def __add__(self, right):
         return str(self) + right
@@ -169,7 +178,7 @@ class Nothing(object):
     __nonzero__ = __bool__  # py2
 
     def __format__(self, format_spec):
-        return str.__format__("", format_spec)
+        return str.__format__(self._text, format_spec)
 
 
 class StyleFunctionError(Exception):

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -145,6 +145,33 @@ class Field(object):
         return result
 
 
+class Nothing(object):
+    """Internal class to represent missing values.
+
+    This is used instead of a built-ins like None, "", or 0 to allow
+    us to unambiguously identify a missing value.  In terms of
+    methods, it tries to mimic an empty string because that behavior
+    is the most useful internally for formatting the output.
+    """
+
+    def __str__(self):
+        return ""
+
+    def __add__(self, right):
+        return str(self) + right
+
+    def __radd__(self, left):
+        return left + str(self)
+
+    def __bool__(self):
+        return False
+
+    __nonzero__ = __bool__  # py2
+
+    def __format__(self, format_spec):
+        return str.__format__("", format_spec)
+
+
 class StyleFunctionError(Exception):
     """Signal that a style function failed.
     """
@@ -224,6 +251,8 @@ class StyleProcessors(object):
         """Return a processor for a style's "transform" function.
         """
         def transform_fn(_, result):
+            if isinstance(result, Nothing):
+                return result
             try:
                 return function(result)
             except:

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -330,7 +330,11 @@ class StyleProcessors(object):
         A function.
         """
         def by_interval_lookup_fn(value, result):
-            value = float(value)
+            try:
+                value = float(value)
+            except TypeError:
+                return result
+
             for start, end, lookup_value in intervals:
                 if start is None:
                     start = float("-inf")

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -181,7 +181,7 @@ class Tabular(object):
             is_auto = style_width == "auto" or _safe_get(style_width, "auto")
 
             if is_auto:
-                width = _safe_get(style_width, "min", 1)
+                width = _safe_get(style_width, "min", 0)
                 wmax = _safe_get(style_width, "max")
 
                 self._autowidth_columns[column] = {"max": wmax}

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -527,6 +527,8 @@ class Tabular(object):
             self._normalizer = self._choose_normalizer(row)
         row = self._normalizer(row)
         callables = self._strip_callables(row)
+        # Fill in any missing values.
+        row = {c: row.get(c, NOTHING) for c in self._columns}
 
         with self._write_lock():
             if not self._rows:

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -13,7 +13,9 @@ from multiprocessing.dummy import Pool
 from blessings import Terminal
 
 from pyout import elements
-from pyout.field import Field, StyleProcessors
+from pyout.field import Field, StyleProcessors, Nothing
+
+NOTHING = Nothing()
 
 
 class TermProcessors(StyleProcessors):
@@ -416,7 +418,7 @@ class Tabular(object):
             if isinstance(value, tuple):
                 initial, fn = value
             else:
-                initial = ""
+                initial = NOTHING
                 # Value could be a normal (non-callable) value or a
                 # callable with no initial value.
                 fn = value

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -527,8 +527,13 @@ class Tabular(object):
             self._normalizer = self._choose_normalizer(row)
         row = self._normalizer(row)
         callables = self._strip_callables(row)
+
         # Fill in any missing values.
-        row = {c: row.get(c, NOTHING) for c in self._columns}
+        for column in self._columns:
+            if column in row:
+                continue
+            missing = self._style[column].get("missing")
+            row[column] = Nothing(missing) if missing else NOTHING
 
         with self._write_lock():
             if not self._rows:

--- a/pyout/tests/test_field.py
+++ b/pyout/tests/test_field.py
@@ -37,13 +37,15 @@ def test_field_processors():
         field.add("pre", "not registered key")
 
 
-def test_something_about_nothing():
-    nada = Nothing()
+@pytest.mark.parametrize("text", ["", "-"], ids=["text=''", "text='-'"])
+def test_something_about_nothing(text):
+    nada = Nothing(text=text)
     assert not nada
-    assert str(nada) == ""
-    assert "{:5}".format(nada) == "     "
-    assert "x" + nada  == "x"
-    assert nada + "x"  == "x"
+
+    assert str(nada) == text
+    assert "{:5}".format(nada) == "{:5}".format(text)
+    assert "x" + nada  == "x" + text
+    assert nada + "x"  == text + "x"
 
 
 def test_truncate_mark_true():

--- a/pyout/tests/test_field.py
+++ b/pyout/tests/test_field.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
-from pyout.field import Field, StyleProcessors
+from pyout.field import Field, Nothing, StyleProcessors
 
 
 def test_field_base():
@@ -35,6 +35,15 @@ def test_field_processors():
 
     with pytest.raises(ValueError):
         field.add("pre", "not registered key")
+
+
+def test_something_about_nothing():
+    nada = Nothing()
+    assert not nada
+    assert str(nada) == ""
+    assert "{:5}".format(nada) == "     "
+    assert "x" + nada  == "x"
+    assert nada + "x"  == "x"
 
 
 def test_truncate_mark_true():

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -52,6 +52,14 @@ def test_tabular_write_color():
 
 
 @patch("pyout.tabular.Terminal", TestTerminal)
+def test_tabular_write_empty_string():
+    fd = StringIO()
+    out = Tabular(stream=fd)
+    out({"name": ""})
+    assert eq_repr(fd.getvalue(), "\n")
+
+
+@patch("pyout.tabular.Terminal", TestTerminal)
 def test_tabular_write_columns_from_orderdict_row():
     fd = StringIO()
     out = Tabular(style={"name": {"width": 3},

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -79,6 +79,21 @@ def test_tabular_write_missing_column_missing_text():
 
 
 @patch("pyout.tabular.Terminal", TestTerminal)
+def test_tabular_write_missing_column_missing_object_data():
+    class Data(object):
+        name = "solo"
+    data = Data()
+
+    fd = StringIO()
+    out = Tabular(columns=["name", "status"],
+                  style={"status":
+                         {"missing": "-"}},
+                  stream=fd)
+    out(data)
+    assert eq_repr(fd.getvalue(), "solo -\n")
+
+
+@patch("pyout.tabular.Terminal", TestTerminal)
 def test_tabular_write_columns_from_orderdict_row():
     fd = StringIO()
     out = Tabular(style={"name": {"width": 3},

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -898,6 +898,26 @@ def test_tabular_write_callable_values():
 
 @pytest.mark.timeout(10)
 @patch("pyout.tabular.Terminal", TestTerminal)
+def test_tabular_write_callable_transform_nothing():
+    delay0 = Delayed(3)
+
+    fd = StringIO()
+    out = Tabular(["name", "status"],
+                  style={"status": {"transform": lambda n: n + 2}},
+                  stream=fd)
+    with out:
+        # The unspecified initial value is set to Nothing().  The
+        # transform function above, which is designed to take a
+        # number, won't be called with it.
+        out({"name": "foo", "status": delay0.run})
+        assert eq_repr(fd.getvalue(), "foo \n")
+        delay0.now = True
+    lines = fd.getvalue().splitlines()
+    assert len([ln for ln in lines if ln.endswith("foo 5")]) == 1
+
+
+@pytest.mark.timeout(10)
+@patch("pyout.tabular.Terminal", TestTerminal)
 def test_tabular_write_callable_values_multi_return():
     delay = Delayed({"status": "done", "path": "/tmp/a"})
 

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -60,6 +60,14 @@ def test_tabular_write_empty_string():
 
 
 @patch("pyout.tabular.Terminal", TestTerminal)
+def test_tabular_write_missing_column():
+    fd = StringIO()
+    out = Tabular(columns=["name", "status"], stream=fd)
+    out({"name": "solo"})
+    assert eq_repr(fd.getvalue(), "solo \n")
+
+
+@patch("pyout.tabular.Terminal", TestTerminal)
 def test_tabular_write_columns_from_orderdict_row():
     fd = StringIO()
     out = Tabular(style={"name": {"width": 3},

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -643,6 +643,27 @@ def test_tabular_write_intervals_bold():
     assert eq_repr(fd.getvalue(), expected)
 
 
+
+@patch("pyout.tabular.Terminal", TestTerminal)
+def test_tabular_write_intervals_missing():
+    fd = StringIO()
+    out = Tabular(style={"name": {"width": 3},
+                         "percent": {"bold": {"interval":
+                                              [[30, 50, False],
+                                               [50, 80, True]]},
+                                     "width": 2}},
+                  stream=fd, force_styling=True)
+    out(OrderedDict([("name", "foo"),
+                     ("percent", 78)]))
+    # Interval lookup function can handle a missing value.
+    out(OrderedDict([("name", "bar")]))
+
+    expected = "foo " + unicode_cap("bold") + \
+               "78" + unicode_cap("sgr0") + "\n" + \
+               "bar   \n"
+    assert eq_repr(fd.getvalue(), expected)
+
+
 @patch("pyout.tabular.Terminal", TestTerminal)
 def test_tabular_write_transform():
     fd = StringIO()

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -68,6 +68,17 @@ def test_tabular_write_missing_column():
 
 
 @patch("pyout.tabular.Terminal", TestTerminal)
+def test_tabular_write_missing_column_missing_text():
+    fd = StringIO()
+    out = Tabular(columns=["name", "status"],
+                  style={"status":
+                         {"missing": "-"}},
+                  stream=fd)
+    out({"name": "solo"})
+    assert eq_repr(fd.getvalue(), "solo -\n")
+
+
+@patch("pyout.tabular.Terminal", TestTerminal)
 def test_tabular_write_columns_from_orderdict_row():
     fd = StringIO()
     out = Tabular(style={"name": {"width": 3},


### PR DESCRIPTION

* Provide a class to represent missing values and don't call the
  transformers if we encounter it.

* If the passed data is missing a column's key/attribute, fill it in
  with a missing value.

Closes #37.
