### PR TITLE
BF: by_lookup: Allow non-hashable values

### DIFF
--- a/pyout/field.py
+++ b/pyout/field.py
@@ -111,7 +111,7 @@ class Field(object):
     def _format(self, _, result):
         """Wrap format call as a two-argument processor function.
         """
-        return self._fmt.format(result)
+        return self._fmt.format(str(result))
 
     def __call__(self, value, keys=None, exclude_post=False):
         """Render `value` by feeding it through the processors.

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -304,7 +304,9 @@ class StyleProcessors(object):
         def by_lookup_fn(value, result):
             try:
                 lookup_value = mapping[value]
-            except KeyError:
+            except (KeyError, TypeError):
+                # ^ TypeError is included in case the user passes
+                # non-hashable values.
                 return result
 
             if not lookup_value:

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -79,6 +79,14 @@ def test_tabular_write_missing_column_missing_text():
 
 
 @patch("pyout.tabular.Terminal", TestTerminal)
+def test_tabular_write_list_value():
+    fd = StringIO()
+    out = Tabular(columns=["name", "status"], stream=fd)
+    out({"name": "foo", "status": [0, 1]})
+    assert eq_repr(fd.getvalue(), "foo [0, 1]\n")
+
+
+@patch("pyout.tabular.Terminal", TestTerminal)
 def test_tabular_write_missing_column_missing_object_data():
     class Data(object):
         name = "solo"

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -570,6 +570,16 @@ def test_tabular_write_label_bold_false():
 
 
 @patch("pyout.tabular.Terminal", TestTerminal)
+def test_tabular_write_label_non_hashable():
+    fd = StringIO()
+    out = Tabular(style={"status": {"color": {"label": {"BAD": "red"}}}},
+                  stream=fd)
+    out(OrderedDict([("status", [0, 1])]))
+    expected = ("[0, 1]\n")
+    assert eq_repr(fd.getvalue(), expected)
+
+
+@patch("pyout.tabular.Terminal", TestTerminal)
 def test_tabular_write_intervals_color():
     fd = StringIO()
     out = Tabular(style={"name": {"width": 3},


### PR DESCRIPTION
Prevent an error when a non-hashable is passed for a column that has a
label style.

Re: https://github.com/pyout/pyout/issues/46#issuecomment-364713320
