### PR TITLE
Don't underline flanking whitespace

### DIFF
--- a/pyout/field.py
+++ b/pyout/field.py
@@ -203,8 +203,13 @@ class StyleProcessors(object):
         expected type.
     """
 
-    style_keys = [("bold", bool),
-                  ("underline", bool),
+    # Sadly, the order matters here because we want "underline" to
+    # ignore flanking whitespace, which means it needs to get the
+    # string before "bold" or "color" change the value.  The need for
+    # this kludge suggests that this class, or perhaps even Field,
+    # should be redesigned.
+    style_keys = [("underline", bool),
+                  ("bold", bool),
                   ("color", str)]
 
     def render(self, key, value):

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -207,17 +207,19 @@ class StyleProcessors(object):
                   ("underline", bool),
                   ("color", str)]
 
-    def translate(self, name):
-        """Translate a style key for a given output type.
+    def render(self, key, value):
+        """Render `value` according to a style key.
 
         Parameters
         ----------
-        name : str
+        key : str
             A style key (e.g., "bold").
+        value : str
+            The value to render.
 
         Returns
         -------
-        An output-specific translation of `name`.
+        An output-specific styling of `value` (str).
         """
         raise NotImplementedError
 
@@ -287,14 +289,14 @@ class StyleProcessors(object):
         Parameters
         ----------
         key : str
-            A style key to be translated.
+            A style key to be applied to the result.
 
         Returns
         -------
         A function.
         """
         def by_key_fn(_, result):
-            return self.translate(key) + result
+            return self.render(key, result)
         return by_key_fn
 
     def by_lookup(self, mapping, key=None):
@@ -307,8 +309,8 @@ class StyleProcessors(object):
             given, a map from the field value to a value that
             indicates whether the processor should style its result.
         key : str, optional
-            A style key to be translated.  If not given, the value
-            from `mapping` is used.
+            A style key to be applied to the result.  If not given,
+            the value from `mapping` is used.
 
         Returns
         -------
@@ -324,7 +326,7 @@ class StyleProcessors(object):
 
             if not lookup_value:
                 return result
-            return self.translate(key or lookup_value) + result
+            return self.render(key or lookup_value, result)
         return by_lookup_fn
 
     def by_interval_lookup(self, intervals, key=None):
@@ -337,8 +339,8 @@ class StyleProcessors(object):
             start is the start of the interval (inclusive) , end is
             the end of the interval, and key is a style key.
         key : str, optional
-            A style key to be translated.  If not given, the value
-            from `mapping` is used.
+            A style key to be applied to the result.  If not given,
+            the value from `mapping` is used.
 
         Returns
         -------
@@ -359,7 +361,7 @@ class StyleProcessors(object):
                 if start <= value < end:
                     if not lookup_value:
                         return result
-                    return self.translate(key or lookup_value) + result
+                    return self.render(key or lookup_value, result)
             return result
         return by_interval_lookup_fn
 

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -44,6 +44,10 @@ class TermProcessors(StyleProcessors):
         The code for `key` (e.g., "\x1b[1m" for bold) plus the
         original value.
         """
+        if not value.strip():
+            # We've got an empty string.  Don't bother adding any
+            # codes.
+            return value
         return str(getattr(self.term, key)) + value
 
     def _maybe_reset(self):

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -9,6 +9,7 @@ from functools import partial
 import inspect
 import multiprocessing
 from multiprocessing.dummy import Pool
+import re
 
 from blessings import Terminal
 
@@ -48,7 +49,14 @@ class TermProcessors(StyleProcessors):
             # We've got an empty string.  Don't bother adding any
             # codes.
             return value
-        return str(getattr(self.term, key)) + value + str(self.term.normal)
+        if key == "underline":
+            strip_re = re.compile(r"(\s*)(.*\S)(\s*)\Z")
+            match = strip_re.match(value)
+            assert match, "This regexp should always match"
+            return (match.group(1) + str(getattr(self.term, key)) +
+                    match.group(2) + self.term.normal +
+                    match.group(3))
+        return str(getattr(self.term, key)) + value + self.term.normal
 
 
 def _safe_get(mapping, key, default=None):

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -48,21 +48,7 @@ class TermProcessors(StyleProcessors):
             # We've got an empty string.  Don't bother adding any
             # codes.
             return value
-        return str(getattr(self.term, key)) + value
-
-    def _maybe_reset(self):
-        def maybe_reset_fn(_, result):
-            if "\x1b" in result:
-                return result + self.term.normal
-            return result
-        return maybe_reset_fn
-
-    def post_from_style(self, column_style):
-        """A Terminal-specific reset to StyleProcessors.post_from_style.
-        """
-        for proc in super(TermProcessors, self).post_from_style(column_style):
-            yield proc
-        yield self._maybe_reset()
+        return str(getattr(self.term, key)) + value + str(self.term.normal)
 
 
 def _safe_get(mapping, key, default=None):

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -29,19 +29,22 @@ class TermProcessors(StyleProcessors):
     def __init__(self, term):
         self.term = term
 
-    def translate(self, name):
-        """Translate a style key into a Terminal code.
+    def render(self, key, value):
+        """Prepend terminal code for `key` to `value`.
 
         Parameters
         ----------
-        name : str
+        key : str
             A style key (e.g., "bold").
+        value : str
+            The value to render.
 
         Returns
         -------
-        An output-specific translation of `name` (e.g., "\x1b[1m").
+        The code for `key` (e.g., "\x1b[1m" for bold) plus the
+        original value.
         """
-        return str(getattr(self.term, name))
+        return str(getattr(self.term, key)) + value
 
     def _maybe_reset(self):
         def maybe_reset_fn(_, result):

--- a/pyout/tests/test_field.py
+++ b/pyout/tests/test_field.py
@@ -91,7 +91,7 @@ def test_style_value_type():
         fn({"unknown": 1})
 
 
-def test_style_processor_translate():
+def test_style_processor_render():
     sp = StyleProcessors()
     with pytest.raises(NotImplementedError):
-        sp.translate("name")
+        sp.render("key", "value")

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -231,7 +231,7 @@ def test_tabular_write_different_data_types_same_output():
 def test_tabular_write_header_with_style():
     fd = StringIO()
     out = Tabular(["name", "status"],
-                  style={"header_": {"underline": True},
+                  style={"header_": {"bold": True},
                          "name": {"width": 4},
                          "status": {"width": 9,
                                     "color": "green"}},
@@ -239,8 +239,8 @@ def test_tabular_write_header_with_style():
     out({"name": "foo",
          "status": "installed"})
 
-    expected = unicode_cap("smul") + "name" + unicode_cap("sgr0") + " " + \
-               unicode_cap("smul") + "status   " + unicode_cap("sgr0") + \
+    expected = unicode_cap("bold") + "name" + unicode_cap("sgr0") + " " + \
+               unicode_cap("bold") + "status   " + unicode_cap("sgr0") + \
                "\nfoo  " + unicode_parm("setaf", COLORNUMS["green"]) + \
                "installed" + unicode_cap("sgr0") + "\n"
     assert eq_repr(fd.getvalue(), expected)

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -321,6 +321,15 @@ def test_tabular_write_multicolor():
 
 
 @patch("pyout.tabular.Terminal", TestTerminal)
+def test_tabular_write_empty_string_nostyle():
+    fd = StringIO()
+    out = Tabular(style={"name": {"color": "green"}},
+                  stream=fd, force_styling=True)
+    out({"name": ""})
+    assert eq_repr(fd.getvalue(), "\n")
+
+
+@patch("pyout.tabular.Terminal", TestTerminal)
 def test_tabular_write_align():
     fd = StringIO()
     out = Tabular(["name"],

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -330,6 +330,25 @@ def test_tabular_write_empty_string_nostyle():
 
 
 @patch("pyout.tabular.Terminal", TestTerminal)
+def test_tabular_write_underline():
+    fd = StringIO()
+    out = Tabular(columns=["name", "status"],
+                  style={"status": {"underline": True,
+                                    "bold": True,
+                                    "align": "center",
+                                    "width": 7},
+                         # Use "," to more easily see spaces in fields.
+                         "separator_": ",",},
+                  stream=fd, force_styling=True)
+    out({"name": "foo", "status": "bad"})
+    # The text is underlined but not the flanking spaces.
+    expected = "foo," + unicode_cap("bold") + "  " + \
+               unicode_cap("smul") + "bad" + unicode_cap("sgr0") + \
+               "  " + unicode_cap("sgr0") + "\n"
+    assert eq_repr(fd.getvalue(), expected)
+
+
+@patch("pyout.tabular.Terminal", TestTerminal)
 def test_tabular_write_align():
     fd = StringIO()
     out = Tabular(["name"],


### PR DESCRIPTION
It works, but the underlying implementation is a bit unsatisfying
because it's a kludge that suggests my design isn't flexible enough to
handle this.

The main issue is the order-dependency.  To underline, we break off
the flanking whitespace, style the core text, and put the whitespace
back.  This needs to before bolding or coloring because they'll
prepend their ansi codes to the string and there will no longer be
leading whitespace.

Perhaps instead of passing the string result, we should pass around
some sort object that discriminates between its core text and its
flanking whitespace and then underline/bold/color can all just work on
the core text.  Dunno.

Anyway, as an example, try

```python
from pyout import Tabular

out = Tabular(columns=["path", "name"],
              style={"separator_": ",",
                     "path": {"underline": True}})

out({"name": "x", "path": " /tmp/x"})
out({"name": "y", "path": "/tmp/y"})
out({"name": "z", "path": "   /tmp/z   "})
```
