### PR TITLE
ENH: Add "delayed" style key

### DIFF
--- a/pyout/common.py
+++ b/pyout/common.py
@@ -194,6 +194,14 @@ class RowNormalizer(object):
 
 
 def _safe_get(mapping, key, default=None):
+    """Helper for accessing style values.
+
+    It exists to avoid checking whether `mapping` is indeed a mapping before
+    trying to get a key.  In the context of style dicts, this eliminates "is
+    this a mapping" checks in two common situations: 1) a style argument is
+    None, and 2) a style key's value (e.g., width) can be either a mapping or a
+    plain value.
+    """
     try:
         return mapping.get(key, default)
     except AttributeError:

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -1,0 +1,168 @@
+"""Common components for styled output.
+
+This modules contains things that would be shared across outputters if there
+were any besides Tabular.  The Tabular class, though, still contains a good
+amount of general logic that should be extracted if any other outputter is
+actually added.
+"""
+
+from collections import Mapping, Sequence
+from functools import partial
+import inspect
+
+from pyout.field import Field, Nothing
+
+NOTHING = Nothing()
+
+
+class RowNormalizer(object):
+    """Transform various input data forms to a common form.
+
+    An un-normalized can be one of three kinds:
+
+      * a mapping from column names to keys
+
+      * a sequence of values in the same order as `columns`
+
+      * any other value will be taken as an object where the column values can
+        be accessed via an attribute with the same name
+
+    To normalized a row, it is
+
+      * converted to a dict that maps from column names to values
+
+      * all callables are stripped out and replaced with their initial values
+
+      * if the value for a column is missing, it is replaced with a Nothing
+        instance whose value is specified by the column's style (an empty
+        string by default)
+
+    Parameters
+    ----------
+    columns : sequence of str
+        Column names.
+    style : dict, optional
+        Column styles.
+
+    Attributes
+    ----------
+    methods : callable
+        A function that takes a row and returns a normalized one.  This is
+        chosen at time of the first call.  All subsequent calls should use the
+        same kind of row.
+    nothings : dict
+        Maps column name to the placeholder value to use if that column is
+        missing.
+    """
+
+    def __init__(self, columns, style):
+        self._columns = columns
+        self.method = None
+
+        self.nothings = {}  # column => missing value
+
+        for column in columns:
+            cstyle = style[column]
+
+            if "missing" in cstyle:
+                self.nothings[column] = Nothing(cstyle["missing"])
+            else:
+                self.nothings[column] = NOTHING
+
+    def __call__(self, row):
+        """Normalize `row`
+
+        Parameters
+        ----------
+        row : mapping, sequence, or other
+            Data to normalize.
+
+        Returns
+        -------
+        A tuple (callables, row), where `callables` is a list (as returned by
+        `strip_callables`) and `row` is the normalized row.
+        """
+        if self.method is None:
+            self.method = self._choose_normalizer(row)
+        return self.method(row)
+
+    def _choose_normalizer(self, row):
+        if isinstance(row, Mapping):
+            return partial(self._normalize, self.getter_dict)
+        if isinstance(row, Sequence):
+            return partial(self._normalize, self.getter_seq)
+        return partial(self._normalize, self.getter_attrs)
+
+    def _normalize(self, getter, row):
+        if isinstance(row, Mapping):
+            callables = self.strip_callables(row)
+        else:
+            callables = []
+        return callables, self._get(getter, row, self._columns)
+
+    @staticmethod
+    def _get(getter, row, columns):
+        row_norm = {}
+        for col in columns:
+            row_norm[col] = getter(row, col)
+        return row_norm
+
+    @staticmethod
+    def strip_callables(row):
+        """Extract callable values from `row`.
+
+        Replace the callable values with the initial value (if specified) or
+        an empty string.
+
+        Parameters
+        ----------
+        row : mapping
+            A data row.  The keys are either a single column name or a tuple of
+            column names.  The values take one of three forms: 1) a
+            non-callable value, 2) a tuple (initial_value, callable), 3) or a
+            single callable (in which case the initial value is set to an empty
+            string).
+
+        Returns
+        -------
+        list of (column, callable)
+        """
+        callables = []
+        to_delete = []
+        to_add = []
+        for columns, value in row.items():
+            if isinstance(value, tuple):
+                initial, fn = value
+            else:
+                initial = NOTHING
+                # Value could be a normal (non-callable) value or a
+                # callable with no initial value.
+                fn = value
+
+            if callable(fn) or inspect.isgenerator(fn):
+                if not isinstance(columns, tuple):
+                    columns = columns,
+                else:
+                    to_delete.append(columns)
+                for column in columns:
+                    to_add.append((column, initial))
+                callables.append((columns, fn))
+
+        for column, value in to_add:
+            row[column] = value
+        for multi_columns in to_delete:
+            del row[multi_columns]
+
+        return callables
+
+    # Input-specific getters
+
+    def getter_dict(self, row, column):
+        return row.get(column, self.nothings[column])
+
+    def getter_seq(self, row, column):
+        col_to_idx = {c: idx for idx, c in enumerate(self._columns)}
+        return row[col_to_idx[column]]
+
+    def getter_attrs(self, row, column):
+        return getattr(row, column, self.nothings[column])

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -98,10 +98,12 @@ class RowNormalizer(object):
 
     def _choose_normalizer(self, row):
         if isinstance(row, Mapping):
-            return partial(self._normalize, self.getter_dict)
-        if isinstance(row, Sequence):
-            return partial(self._normalize, self.getter_seq)
-        return partial(self._normalize, self.getter_attrs)
+            getter = self.getter_dict
+        elif isinstance(row, Sequence):
+            getter = self.getter_seq
+        else:
+            getter = self.getter_attrs
+        return partial(self._normalize, getter)
 
     def _normalize(self, getter, row):
         if isinstance(row, Mapping):

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -58,6 +58,7 @@ schema = {
             "properties": {"align": {"$ref": "#/definitions/align"},
                            "bold": {"$ref": "#/definitions/bold"},
                            "color": {"$ref": "#/definitions/color"},
+                           "delayed": {"$ref": "#/definitions/delayed"},
                            "missing": {"$ref": "#/definitions/missing"},
                            "transform": {"$ref": "#/definitions/transform"},
                            "underline": {"$ref": "#/definitions/underline"},
@@ -81,6 +82,15 @@ schema = {
             "type": "object",
             "properties": {"lookup": {"type": "object"}},
             "additionalProperties": False},
+        "delayed": {
+            "description": """Don't wait for this column's value.
+            The accessor will be wrapped in a function and called
+            asynchronously.  This can be set to a string to mark columns as
+            part of a "group".  All columns within a group will be accessed
+            within the same callable.  True means to access the column's value
+            in its own callable (i.e. independently of other columns).""",
+            "type": ["boolean", "string"],
+            "scope": "field"},
         "transform": {
             "description": """An arbitrary function.
             This function will be called with the (unprocessed) field value as

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -424,3 +424,43 @@ class StyleProcessors(object):
             elif vtype == "interval":
                 yield self.by_interval_lookup(column_style[key][vtype],
                                               attr_key)
+
+
+class TermProcessors(StyleProcessors):
+    """Generate Field.processors for styled Terminal output.
+
+    Parameters
+    ----------
+    term : blessings.Terminal
+    """
+
+    def __init__(self, term):
+        self.term = term
+
+    def translate(self, name):
+        """Translate a style key into a Terminal code.
+
+        Parameters
+        ----------
+        name : str
+            A style key (e.g., "bold").
+
+        Returns
+        -------
+        An output-specific translation of `name` (e.g., "\x1b[1m").
+        """
+        return str(getattr(self.term, name))
+
+    def _maybe_reset(self):
+        def maybe_reset_fn(_, result):
+            if "\x1b" in result:
+                return result + self.term.normal
+            return result
+        return maybe_reset_fn
+
+    def post_from_style(self, column_style):
+        """A Terminal-specific reset to StyleProcessors.post_from_style.
+        """
+        for proc in super(TermProcessors, self).post_from_style(column_style):
+            yield proc
+        yield self._maybe_reset()

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -97,11 +97,14 @@ class Tabular(object):
         self._autowidth_columns = {}
 
         if columns is not None:
-            self._setup_style()
-            self._setup_fields()
+            self._init_after_columns()
 
         self._pool = None
         self._lock = None
+
+    def _init_after_columns(self):
+        self._setup_style()
+        self._setup_fields()
 
     def __enter__(self):
         return self
@@ -475,8 +478,7 @@ class Tabular(object):
         """
         if self._columns is None:
             self._columns = self._infer_columns(row)
-            self._setup_style()
-            self._setup_fields()
+            self._init_after_columns()
 
         if self._normalizer is None:
             self._normalizer = self._choose_normalizer(row)

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -343,8 +343,6 @@ class Tabular(object):
 
         if isinstance(self._columns, OrderedDict):
             row = self._columns
-        elif self._normalizer == self._seq_to_dict:
-            row = self._normalizer(self._columns)
         else:
             row = dict(zip(self._columns, self._columns))
 

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -13,50 +13,9 @@ from multiprocessing.dummy import Pool
 from blessings import Terminal
 
 from pyout import elements
-from pyout.field import Field, StyleProcessors, Nothing
+from pyout.field import Field, TermProcessors, Nothing
 
 NOTHING = Nothing()
-
-
-class TermProcessors(StyleProcessors):
-    """Generate Field.processors for styled Terminal output.
-
-    Parameters
-    ----------
-    term : blessings.Terminal
-    """
-
-    def __init__(self, term):
-        self.term = term
-
-    def translate(self, name):
-        """Translate a style key into a Terminal code.
-
-        Parameters
-        ----------
-        name : str
-            A style key (e.g., "bold").
-
-        Returns
-        -------
-        An output-specific translation of `name` (e.g., "\x1b[1m").
-        """
-        return str(getattr(self.term, name))
-
-    def _maybe_reset(self):
-        def maybe_reset_fn(_, result):
-            if "\x1b" in result:
-                return result + self.term.normal
-            return result
-        return maybe_reset_fn
-
-    def post_from_style(self, column_style):
-        """A Terminal-specific reset to StyleProcessors.post_from_style.
-        """
-        for proc in super(TermProcessors, self).post_from_style(column_style):
-            yield proc
-        yield self._maybe_reset()
-
 
 def _safe_get(mapping, key, default=None):
     try:


### PR DESCRIPTION
The last commit of this series adds the ability to "delay" accessing a column's value by wrapping it in a callable.  The delayed values can be grouped by using the same string.

This change forced me to deal (at least partially) with Tabular's bloat rather than add to it.  The other commits in this series do that restructuring or related cleanup.

This is the relevant diff for the delayed feature: https://github.com/pyout/pyout/compare/928363735749d2f85c0827bc8dd3165c241080e4...f22841058581ff0bd4341af3974137b1e8e0ab87

------------------------------------------------------------------------

demo:

```python
import time
from pyout import Tabular


class Data(object):
    def __init__(self, name, path, status, date):
        self.name = name
        self._path = path
        self._status = status
        self.date = date

    @property
    def path(self):
        time.sleep(1)
        return self._path

    @property
    def status(self):
        time.sleep(4)
        return self._status

out = Tabular(columns=["name", "path", "status", "date"],
              style={"path": {"delayed": "ps"},
                     "status": {"delayed": "ps"},
                     "date": {"delayed": True}})

with out:
    out(Data("x", "/tmp/x", "good", 2012))
    out(Data("y", "/tmp/y", "bad", 2013))
    out(Data("z", "/tmp/z", "ok", 2014))

```
