### PR TITLE
[DO NOT MERGE] ENH: Split off flanking whitespace before styling value

### DIFF
--- a/pyout/field.py
+++ b/pyout/field.py
@@ -454,6 +454,10 @@ class TermProcessors(StyleProcessors):
         The code for `key` (e.g., "\x1b[1m" for bold) plus the
         original value.
         """
+        if not value.strip():
+            # We've got an empty string.  Don't bother adding any
+            # codes.
+            return value
         return str(getattr(self.term, key)) + value
 
     def _maybe_reset(self):

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -201,17 +201,19 @@ class StyleProcessors(object):
                   ("underline", bool),
                   ("color", str)]
 
-    def translate(self, name):
-        """Translate a style key for a given output type.
+    def render(self, key, value):
+        """Render `value` according to a style key.
 
         Parameters
         ----------
-        name : str
+        key : str
             A style key (e.g., "bold").
+        value : str
+            The value to render.
 
         Returns
         -------
-        An output-specific translation of `name`.
+        An output-specific styling of `value` (str).
         """
         raise NotImplementedError
 
@@ -281,14 +283,14 @@ class StyleProcessors(object):
         Parameters
         ----------
         key : str
-            A style key to be translated.
+            A style key to be applied to the result.
 
         Returns
         -------
         A function.
         """
         def by_key_fn(_, result):
-            return self.translate(key) + result
+            return self.render(key, result)
         return by_key_fn
 
     def by_lookup(self, mapping, key=None):
@@ -301,8 +303,8 @@ class StyleProcessors(object):
             map from the field value to a value that indicates whether the
             processor should style its result.
         key : str, optional
-            A style key to be translated.  If not given, the value from
-            `mapping` is used.
+            A style key to be applied to the result.  If not given, the value
+            from `mapping` is used.
 
         Returns
         -------
@@ -318,7 +320,7 @@ class StyleProcessors(object):
 
             if not lookup_value:
                 return result
-            return self.translate(key or lookup_value) + result
+            return self.render(key or lookup_value, result)
         return by_lookup_fn
 
     def by_interval_lookup(self, intervals, key=None):
@@ -331,8 +333,8 @@ class StyleProcessors(object):
             the start of the interval (inclusive) , end is the end of the
             interval, and key is a style key.
         key : str, optional
-            A style key to be translated.  If not given, the value from
-            `mapping` is used.
+            A style key to be applied to the result.  If not given, the value
+            from `mapping` is used.
 
         Returns
         -------
@@ -353,7 +355,7 @@ class StyleProcessors(object):
                 if start <= value < end:
                     if not lookup_value:
                         return result
-                    return self.translate(key or lookup_value) + result
+                    return self.render(key or lookup_value, result)
             return result
         return by_interval_lookup_fn
 
@@ -437,19 +439,22 @@ class TermProcessors(StyleProcessors):
     def __init__(self, term):
         self.term = term
 
-    def translate(self, name):
-        """Translate a style key into a Terminal code.
+    def render(self, key, value):
+        """Prepend terminal code for `key` to `value`.
 
         Parameters
         ----------
-        name : str
+        key : str
             A style key (e.g., "bold").
+        value : str
+            The value to render.
 
         Returns
         -------
-        An output-specific translation of `name` (e.g., "\x1b[1m").
+        The code for `key` (e.g., "\x1b[1m" for bold) plus the
+        original value.
         """
-        return str(getattr(self.term, name))
+        return str(getattr(self.term, key)) + value
 
     def _maybe_reset(self):
         def maybe_reset_fn(_, result):

--- a/pyout/tests/test_field.py
+++ b/pyout/tests/test_field.py
@@ -91,7 +91,7 @@ def test_style_value_type():
         fn({"unknown": 1})
 
 
-def test_style_processor_translate():
+def test_style_processor_render():
     sp = StyleProcessors()
     with pytest.raises(NotImplementedError):
-        sp.translate("name")
+        sp.render("key", "value")

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -325,6 +325,15 @@ def test_tabular_write_multicolor():
 
 
 @patch("pyout.tabular.Terminal", TestTerminal)
+def test_tabular_write_empty_string_nostyle():
+    fd = StringIO()
+    out = Tabular(style={"name": {"color": "green"}},
+                  stream=fd, force_styling=True)
+    out({"name": ""})
+    assert eq_repr(fd.getvalue(), "\n")
+
+
+@patch("pyout.tabular.Terminal", TestTerminal)
 def test_tabular_write_align():
     fd = StringIO()
     out = Tabular(["name"],

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -244,7 +244,7 @@ def test_tabular_write_header_with_style():
          "status": "installed"})
 
     expected = unicode_cap("smul") + "name" + unicode_cap("sgr0") + " " + \
-               unicode_cap("smul") + "status   " + unicode_cap("sgr0") + \
+               unicode_cap("smul") + "status" + unicode_cap("sgr0") + "   " + \
                "\nfoo  " + unicode_parm("setaf", COLORNUMS["green"]) + \
                "installed" + unicode_cap("sgr0") + "\n"
     assert eq_repr(fd.getvalue(), expected)
@@ -331,6 +331,23 @@ def test_tabular_write_empty_string_nostyle():
                   stream=fd, force_styling=True)
     out({"name": ""})
     assert eq_repr(fd.getvalue(), "\n")
+
+
+@patch("pyout.tabular.Terminal", TestTerminal)
+def test_tabular_write_style_flanking():
+    fd = StringIO()
+    out = Tabular(columns=["name", "status"],
+                  style={"status": {"underline": True,
+                                    "align": "center",
+                                    "width": 7},
+                         # Use "," to more easily see spaces in fields.
+                         "separator_": ",",},
+                  stream=fd, force_styling=True)
+    out({"name": "foo", "status": "bad"})
+    # The text is style but not the flanking whitespace.
+    expected = "foo," + "  " + \
+               unicode_cap("smul") + "bad" + unicode_cap("sgr0") + "  \n"
+    assert eq_repr(fd.getvalue(), expected)
 
 
 @patch("pyout.tabular.Terminal", TestTerminal)
@@ -545,7 +562,7 @@ def test_tabular_write_lookup_color():
 
     expected = "foo " + "OK    \n" + \
                "bar " + unicode_parm("setaf", COLORNUMS["red"]) + \
-               "BAD   " + unicode_cap("sgr0") + "\n"
+               "BAD" + unicode_cap("sgr0") + "   \n"
     assert eq_repr(fd.getvalue(), expected)
 
 
@@ -563,7 +580,7 @@ def test_tabular_write_lookup_bold():
 
     expected = "foo " + "OK    \n" + \
                "bar " + unicode_cap("bold") + \
-               "BAD   " + unicode_cap("sgr0") + "\n"
+               "BAD" + unicode_cap("sgr0") + "   \n"
     assert eq_repr(fd.getvalue(), expected)
 
 
@@ -610,9 +627,9 @@ def test_tabular_write_intervals_color():
                      ("percent", 33)]))
 
     expected = "foo " + unicode_parm("setaf", COLORNUMS["green"]) + \
-               "88     " + unicode_cap("sgr0") + "\n" + \
+               "88" + unicode_cap("sgr0") + "     \n" + \
                "bar " + unicode_parm("setaf", COLORNUMS["red"]) + \
-               "33     " + unicode_cap("sgr0") + "\n"
+               "33" + unicode_cap("sgr0") + "     \n"
     assert eq_repr(fd.getvalue(), expected)
 
 
@@ -631,9 +648,9 @@ def test_tabular_write_intervals_color_open_ended():
                      ("percent", 33)]))
 
     expected = "foo " + unicode_parm("setaf", COLORNUMS["green"]) + \
-               "88     " + unicode_cap("sgr0") + "\n" + \
+               "88" + unicode_cap("sgr0") + "     \n" + \
                "bar " + unicode_parm("setaf", COLORNUMS["red"]) + \
-               "33     " + unicode_cap("sgr0") + "\n"
+               "33" + unicode_cap("sgr0") + "     \n"
     assert eq_repr(fd.getvalue(), expected)
 
 
@@ -652,7 +669,7 @@ def test_tabular_write_intervals_color_outside_intervals():
 
     expected = "foo 88     \n" + \
                "bar " + unicode_parm("setaf", COLORNUMS["red"]) + \
-               "33     " + unicode_cap("sgr0") + "\n"
+               "33" + unicode_cap("sgr0") + "     \n"
     assert eq_repr(fd.getvalue(), expected)
 
 


### PR DESCRIPTION
This supersedes #52, using the [approach] suggested by @yarikoptic. Like the original PR, the end result is that the flanking whitespace in a field is not underlined.

Please look, but don't merge because it is based on #54 rather than
master to avoid conflicts.

[approach]: https://github.com/pyout/pyout/pull/52#issuecomment-365133088

Another demo:

```python
from pyout import Tabular

out = Tabular(columns=["path", "name"],
              style={"separator_": ",",
                     "path": {"underline": True}})

out({"name": "x", "path": " one on left"})
out({"name": "y", "path": "two on right  "})
out({"name": "z", "path": "  two each  "})
```
