### PR TITLE
Add support for summary lines

### DIFF
--- a/pyout/__init__.py
+++ b/pyout/__init__.py
@@ -3,6 +3,8 @@
 Exposes a single entry point, the Tabular class.
 """
 
+from __future__ import unicode_literals
+
 __version__ = "0.1.0"
 
 from pyout.elements import schema

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -251,7 +251,7 @@ class StyleFields(object):
         # Store special keys in _style so that they can be validated.
         self.style["default_"] = default
         self.style["header_"] = self._compose("header_", {"align", "width"})
-        self.style["summary_"] = self._compose("summary_", {"align", "width"})
+        self.style["aggregate_"] = self._compose("aggregate_", {"align", "width"})
         self.style["separator_"] = _safe_get(self.init_style, "separator_",
                                              elements.default("separator_"))
         elements.validate(self.style)

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -499,9 +499,9 @@ class Content(object):
         for i in chain(self._rows, summary_rows):
             yield i
 
-    def __iter__(self):
+    def _render(self, rows):
         adjusted = []
-        for row, kwds in self.rows:
+        for row, kwds in rows:
             line, adj = self.fields.render(row, **kwds)
             yield line
             # Continue processing so that we get all the adjustments out of
@@ -512,9 +512,9 @@ class Content(object):
 
     def __str__(self):
         try:
-            return "".join(self)
+            return "".join(self._render(self.rows))
         except RedoContent:
-            return "".join(self)
+            return "".join(self._render(self.rows))
 
     def update(self, row, style):
         """Modify the content.

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -6,9 +6,13 @@ amount of general logic that should be extracted if any other outputter is
 actually added.
 """
 
+from __future__ import unicode_literals
+
 from collections import defaultdict, Mapping, Sequence
 from functools import partial
 import inspect
+
+import six
 
 from pyout import elements
 from pyout.field import Field, Nothing
@@ -330,7 +334,7 @@ class StyleFields(object):
                                   exclude_post=True)
                 else:
                     value = row[column]
-                value_width = len(str(value))
+                value_width = len(six.text_type(value))
                 wmax = self.autowidth_columns[column]["max"]
                 if value_width > field.width:
                     if wmax is None or field.width < wmax:

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -446,7 +446,7 @@ class Content(object):
 
     Parameters
     ----------
-    fields : StyleField instances
+    fields : StyleField instance
     """
 
     def __init__(self, fields):
@@ -530,8 +530,8 @@ class Content(object):
 
         Returns
         -------
-        A tuple of (content, status), where status is either 'append', an
-        integer, or 'repaint'.
+        A tuple of (content, status), where status is 'append', an integer, or
+        'repaint'.
 
           * append: the only change in the content is the addition of a line,
             and the returned content will consist of just this line.
@@ -561,7 +561,7 @@ class Content(object):
                           if not isinstance(v, Nothing)}
             self._rows[prev_idx].row.update(row_update)
             self._rows[prev_idx].kwds.update({"style": style})
-            # Replace the passed-in row since it may not have the all columns.
+            # Replace the passed-in row since it may not have all the columns.
             row = self._rows[prev_idx][0]
         else:
             self._idmap[idkey] = len(self._rows)

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -575,7 +575,7 @@ class Content(object):
             # multiple lines and "append"/idx.
             return six.text_type(self), "repaint"
         if not adjusted and prev_idx is not None:
-            return line, prev_idx
+            return line, prev_idx + self.fields.has_header
         return line, "append"
 
     def _add_header(self):

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -548,7 +548,7 @@ class Content(object):
         if not called_before and self.fields.has_header:
             self._add_header()
             self._rows.append(ContentRow(row, kwds={"style": style}))
-            self._idmap[idkey] = len(self)
+            self._idmap[idkey] = 0
             return six.text_type(self), "append"
 
         try:

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -7,7 +7,7 @@ from collections import Mapping
 
 schema = {
     "definitions": {
-        # Styles
+        # Plain style elements
         "align": {
             "description": "Alignment of text",
             "type": "string",
@@ -30,12 +30,6 @@ schema = {
                       {"$ref": "#/definitions/interval"}],
             "default": "black",
             "scope": "field"},
-        "missing": {
-            "description": "Text to display for missing values",
-            "type": "string",
-            "default": "",
-            "scope": "column"
-        },
         "underline": {
             "description": "Whether text is underlined",
             "oneOf": [{"type": "boolean"},
@@ -55,6 +49,30 @@ schema = {
                            "min": {"type": ["integer", "null"]}}}],
             "default": "auto",
             "scope": "column"},
+        # Other style elements
+        "delayed": {
+            "description": """Don't wait for this column's value.
+            The accessor will be wrapped in a function and called
+            asynchronously.  This can be set to a string to mark columns as
+            part of a "group".  All columns within a group will be accessed
+            within the same callable.  True means to access the column's value
+            in its own callable (i.e. independently of other columns).""",
+            "type": ["boolean", "string"],
+            "scope": "field"},
+        "missing": {
+            "description": "Text to display for missing values",
+            "type": "string",
+            "default": "",
+            "scope": "column"
+        },
+        "transform": {
+            "description": """An arbitrary function.
+            This function will be called with the (unprocessed) field value as
+            the single argument and should return a transformed value.  Note:
+            This function should not have side-effects because it may be called
+            multiple times.""",
+            "scope": "field"},
+        # Complete list of column style elements
         "styles": {
             "type": "object",
             "properties": {"align": {"$ref": "#/definitions/align"},
@@ -66,7 +84,7 @@ schema = {
                            "underline": {"$ref": "#/definitions/underline"},
                            "width": {"$ref": "#/definitions/width"}},
             "additionalProperties": False},
-        # Mapping types
+        # Mapping elements
         "interval": {
             "description": "Map a value within an interval to a style",
             "type": "object",
@@ -83,23 +101,7 @@ schema = {
             "description": "Map a value to a style",
             "type": "object",
             "properties": {"lookup": {"type": "object"}},
-            "additionalProperties": False},
-        "delayed": {
-            "description": """Don't wait for this column's value.
-            The accessor will be wrapped in a function and called
-            asynchronously.  This can be set to a string to mark columns as
-            part of a "group".  All columns within a group will be accessed
-            within the same callable.  True means to access the column's value
-            in its own callable (i.e. independently of other columns).""",
-            "type": ["boolean", "string"],
-            "scope": "field"},
-        "transform": {
-            "description": """An arbitrary function.
-            This function will be called with the (unprocessed) field value as
-            the single argument and should return a transformed value.  Note:
-            This function should not have side-effects because it may be called
-            multiple times.""",
-            "scope": "field"}
+            "additionalProperties": False}
     },
     "type": "object",
     "properties": {

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -50,6 +50,11 @@ schema = {
             "default": "auto",
             "scope": "column"},
         # Other style elements
+        "aggregate": {
+            "description": """A function that produces a summary value.  This
+            function will be called with all of the column's the (unprocessed)
+            field values and should return a single value to be displayed.""",
+            "scope": "column"},
         "delayed": {
             "description": """Don't wait for this column's value.
             The accessor will be wrapped in a function and called
@@ -75,7 +80,8 @@ schema = {
         # Complete list of column style elements
         "styles": {
             "type": "object",
-            "properties": {"align": {"$ref": "#/definitions/align"},
+            "properties": {"aggregate": {"$ref": "#/definitions/aggregate"},
+                           "align": {"$ref": "#/definitions/align"},
                            "bold": {"$ref": "#/definitions/bold"},
                            "color": {"$ref": "#/definitions/color"},
                            "delayed": {"$ref": "#/definitions/delayed"},
@@ -126,6 +132,16 @@ schema = {
             "description": "Separator used between fields",
             "type": "string",
             "default": " ",
+            "scope": "table"},
+        "summary_": {
+            "description": "Shared attributes for the summary rows",
+            "oneOf": [{"type": "object",
+                       "properties":
+                       {"color": {"$ref": "#/definitions/color"},
+                        "bold": {"$ref": "#/definitions/bold"},
+                        "underline": {"$ref": "#/definitions/underline"}}},
+                      {"type": "null"}],
+            "default": {},
             "scope": "table"}
     },
     # All other keys are column names.

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -1,6 +1,8 @@
 """Style elements and schema validation.
 """
 
+from __future__ import unicode_literals
+
 from collections import Mapping
 
 schema = {

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -111,6 +111,16 @@ schema = {
     },
     "type": "object",
     "properties": {
+        "aggregate_": {
+            "description": "Shared attributes for the summary rows",
+            "oneOf": [{"type": "object",
+                       "properties":
+                       {"color": {"$ref": "#/definitions/color"},
+                        "bold": {"$ref": "#/definitions/bold"},
+                        "underline": {"$ref": "#/definitions/underline"}}},
+                      {"type": "null"}],
+            "default": {},
+            "scope": "table"},
         "default_": {
             "description": "Default style of columns",
             "oneOf": [{"$ref": "#/definitions/styles"},
@@ -132,16 +142,6 @@ schema = {
             "description": "Separator used between fields",
             "type": "string",
             "default": " ",
-            "scope": "table"},
-        "summary_": {
-            "description": "Shared attributes for the summary rows",
-            "oneOf": [{"type": "object",
-                       "properties":
-                       {"color": {"$ref": "#/definitions/color"},
-                        "bold": {"$ref": "#/definitions/bold"},
-                        "underline": {"$ref": "#/definitions/underline"}}},
-                      {"type": "null"}],
-            "default": {},
             "scope": "table"}
     },
     # All other keys are column names.

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -1,5 +1,7 @@
 """Define a "field" based on a sequence of processor functions.
 """
+from __future__ import unicode_literals
+
 from itertools import chain
 from collections import defaultdict
 import re
@@ -105,12 +107,12 @@ class Field(object):
 
     def _build_format(self):
         align = self._align_values[self._align]
-        return "".join(["{:", align, str(self.width), "}"])
+        return "".join(["{:", align, six.text_type(self.width), "}"])
 
     def _format(self, _, result):
         """Wrap format call as a two-argument processor function.
         """
-        return self._fmt.format(str(result))
+        return self._fmt.format(six.text_type(result))
 
     def __call__(self, value, keys=None, exclude_post=False):
         """Render `value` by feeding it through the processors.
@@ -144,6 +146,7 @@ class Field(object):
         return result
 
 
+@six.python_2_unicode_compatible
 class Nothing(object):
     """Internal class to represent missing values.
 
@@ -165,10 +168,10 @@ class Nothing(object):
         return self._text
 
     def __add__(self, right):
-        return str(self) + right
+        return six.text_type(self) + right
 
     def __radd__(self, left):
-        return left + str(self)
+        return left + six.text_type(self)
 
     def __bool__(self):
         return False
@@ -176,7 +179,7 @@ class Nothing(object):
     __nonzero__ = __bool__  # py2
 
     def __format__(self, format_spec):
-        return str.__format__(self._text, format_spec)
+        return self._text.__format__(format_spec)
 
 
 class StyleFunctionError(Exception):
@@ -492,7 +495,7 @@ class TermProcessors(StyleProcessors):
             # We've got an empty string.  Don't bother adding any
             # codes.
             return value
-        return str(getattr(self.term, key)) + value
+        return six.text_type(getattr(self.term, key)) + value
 
     def _maybe_reset(self):
         def maybe_reset_fn(_, result):

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -78,6 +78,9 @@ class Field(object):
     def add(self, kind, key, *values):
         """Add processor functions.
 
+        Any previous list of processors for `kind` and `key` will be
+        overwritten.
+
         Parameters
         ----------
         kind : {"pre", "post"}
@@ -94,7 +97,7 @@ class Field(object):
         else:
             raise ValueError("kind is not 'pre' or 'post'")
         self._check_if_registered(key)
-        procs[key].extend(values)
+        procs[key] = values
 
     @property
     def width(self):

--- a/pyout/summary.py
+++ b/pyout/summary.py
@@ -1,0 +1,78 @@
+"""Summarize output.
+"""
+
+from __future__ import unicode_literals
+
+from collections import Mapping
+
+from pyout.field import Nothing
+
+
+class Summary(object):
+    """Produce summary rows for a list of normalized rows.
+
+    Parameters
+    ----------
+    style : dict
+        A style that follows the schema defined in pyout.elements.
+    """
+
+    def __init__(self, style):
+        self.style = style
+        self._enabled = any("aggregate" in v for v in self.style.values()
+                            if isinstance(v, Mapping))
+
+    def __bool__(self):
+        return self._enabled
+
+    __nonzero__ = __bool__  # py2
+
+    def summarize(self, rows):
+        """Return summary rows for `rows`.
+
+        Parameters
+        ----------
+        rows : list of dicts
+            Normalized rows to summarize.
+
+        Returns
+        -------
+        A list of summary rows.  Each row is a tuple where the first item is
+        the data and the second is a dict of keyword arguments that can be
+        passed to StyleFields.render.
+        """
+        columns = list(rows[0].keys())
+        agg_styles = {c: self.style[c]["aggregate"]
+                      for c in columns if "aggregate" in self.style[c]}
+
+        summaries = {}
+        for col, agg_fn in agg_styles.items():
+            colvals = filter(lambda x: not isinstance(x, Nothing),
+                             (row[col] for row in rows))
+            summaries[col] = agg_fn(list(colvals))
+
+        # The rest is just restructuring the summaries into rows that are
+        # compatible with pyout.Content.  Most the complexity below comes from
+        # the fact that a summary function is allowed to return either a single
+        # item or a list of items.
+        maxlen = max(len(v) if isinstance(v, list) else 1
+                     for v in summaries.values())
+        summary_rows = []
+        for rowidx in range(maxlen):
+            sumrow = {}
+            for column, values in summaries.items():
+                if isinstance(values, list):
+                    if rowidx >= len(values):
+                        continue
+                    sumrow[column] = values[rowidx]
+                elif rowidx == 0:
+                    sumrow[column] = values
+
+            for column in columns:
+                if column not in sumrow:
+                    sumrow[column] = ""
+
+            summary_rows.append((sumrow,
+                                 {"style": self.style.get("summary_"),
+                                  "adopt": False}))
+        return summary_rows

--- a/pyout/summary.py
+++ b/pyout/summary.py
@@ -73,6 +73,6 @@ class Summary(object):
                     sumrow[column] = ""
 
             summary_rows.append((sumrow,
-                                 {"style": self.style.get("summary_"),
+                                 {"style": self.style.get("aggregate_"),
                                   "adopt": False}))
         return summary_rows

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -3,6 +3,8 @@
 This module defines the Tabular entry point.
 """
 
+from __future__ import unicode_literals
+
 from collections import Mapping, OrderedDict, Sequence
 from contextlib import contextmanager
 from functools import partial

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -143,7 +143,13 @@ class Tabular(object):
                 if status == "repaint":
                     self._move_to_firstrow()
                 self.term.stream.write(content)
-            self._last_content_len = len(self._content)
+
+            new_content_len = len(self._content)
+            if new_content_len - self._last_content_len < 0:
+                # We now have fewer lines.  Remove the stale lines.
+                self.term.stream.write(self.term.clear_eos)
+                self.term.stream.flush()
+            self._last_content_len = new_content_len
 
     def _start_callables(self, row, callables):
         """Start running `callables` asynchronously.

--- a/pyout/tests/test_elements.py
+++ b/pyout/tests/test_elements.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import pytest
 from pyout.elements import adopt, StyleError, validate
 

--- a/pyout/tests/test_field.py
+++ b/pyout/tests/test_field.py
@@ -1,4 +1,9 @@
 # -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import six
+
 import pytest
 from pyout.field import Field, Nothing, StyleProcessors
 
@@ -37,12 +42,14 @@ def test_field_processors():
         field.add("pre", "not registered key")
 
 
-@pytest.mark.parametrize("text", ["", "-"], ids=["text=''", "text='-'"])
+@pytest.mark.parametrize("text",
+                         ["", "-", "…"],
+                         ids=["text=''", "text='-'", "text='…'"])
 def test_something_about_nothing(text):
     nada = Nothing(text=text)
     assert not nada
 
-    assert str(nada) == text
+    assert six.text_type(nada) == text
     assert "{:5}".format(nada) == "{:5}".format(text)
     assert "x" + nada  == "x" + text
     assert nada + "x"  == text + "x"
@@ -57,11 +64,11 @@ def test_truncate_mark_true():
 
 
 def test_truncate_mark_string():
-    fn = StyleProcessors.truncate(7, marker=u"…")
+    fn = StyleProcessors.truncate(7, marker="…")
 
     assert fn(None, "abc") == "abc"
     assert fn(None, "abcdefg") == "abcdefg"
-    assert fn(None, "abcdefgh") == u"abcdef…"
+    assert fn(None, "abcdefgh") == "abcdef…"
 
 
 def test_truncate_mark_short():

--- a/pyout/tests/test_summary.py
+++ b/pyout/tests/test_summary.py
@@ -1,0 +1,44 @@
+
+from functools import partial
+from pyout.summary import Summary
+
+
+def eq(result, expect):
+    """Unwrap summarize `result` and assert that it is equal to `expect`.
+    """
+    assert [r[0] for r in result] == expect
+
+
+def test_summary_summarize_atom_return():
+    sm = Summary({"col1": {"aggregate": len}})
+    eq(sm.summarize([{"col1": "a"},
+                     {"col1": "b"}]),
+       [{"col1": 2}])
+
+
+def test_summary_summarize_list_return():
+    def unique_lens(xs):
+        return list(sorted(set(map(len, xs))))
+
+    sm = Summary({"col1": {"aggregate": unique_lens}})
+    eq(sm.summarize([{"col1": "a"},
+                     {"col1": "bcd"},
+                     {"col1": "ef"},
+                     {"col1": "g"}]),
+       [{"col1": 1},
+        {"col1": 2},
+        {"col1": 3}])
+
+
+def test_summary_summarize_multicolumn_return():
+    def unique_values(xs):
+        return list(sorted(set(xs)))
+
+    sm = Summary({"col1": {"aggregate": unique_values},
+                  "col2": {"aggregate": len},
+                  "col3": {"aggregate": unique_values}})
+    eq(sm.summarize([{"col1": "a", "col2": "x", "col3": "c"},
+                     {"col1": "b", "col2": "y", "col3": "c"},
+                     {"col1": "a", "col2": "z", "col3": "c"}]),
+       [{"col1": "a", "col2": 3, "col3": "c"},
+        {"col1": "b", "col2": "", "col3": ""}])

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 from collections import OrderedDict
 from curses import tigetstr, tparm
 from functools import partial
@@ -765,7 +767,7 @@ def test_tabular_write_transform_autowidth():
 @patch("pyout.tabular.Terminal", TestTerminal)
 def test_tabular_write_transform_on_header():
     fd = StringIO()
-    out = Tabular(style={"header_": {"transform": str.upper},
+    out = Tabular(style={"header_": {"transform": lambda x: x.upper()},
                          "name": {"width": 4},
                          "val": {"width": 3}},
                   stream=fd)
@@ -874,8 +876,8 @@ def test_tabular_write_autowidth_min():
     assert len([ln for ln in lines if ln.endswith("fooab OK    /tmp/a")]) == 1
 
 
-@pytest.mark.parametrize("marker", [True, False, u"…"],
-                         ids=["marker=True", "marker=False", u"marker=…"])
+@pytest.mark.parametrize("marker", [True, False, "…"],
+                         ids=["marker=True", "marker=False", "marker=…"])
 @patch("pyout.tabular.Terminal", TestTerminal)
 def test_tabular_write_autowidth_min_max(marker):
     fd = StringIO()
@@ -892,7 +894,7 @@ def test_tabular_write_autowidth_min_max(marker):
     if marker is True:
         assert fd.getvalue() == "foo U  /t...\n"
     elif marker:
-        assert fd.getvalue() == u"foo U  /tmp…\n"
+        assert fd.getvalue() == "foo U  /tmp…\n"
     else:
         assert fd.getvalue() == "foo U  /tmp/\n"
 
@@ -905,8 +907,8 @@ def test_tabular_write_autowidth_min_max(marker):
         assert len([ln for ln in lines if ln.endswith("foo U       /t...")]) == 1
         assert len([ln for ln in lines if ln.endswith("bar BAD!... /t...")]) == 1
     elif marker:
-        assert len([ln for ln in lines if ln.endswith(u"foo U       /tmp…")]) == 1
-        assert len([ln for ln in lines if ln.endswith(u"bar BAD!... /tmp…")]) == 1
+        assert len([ln for ln in lines if ln.endswith("foo U       /tmp…")]) == 1
+        assert len([ln for ln in lines if ln.endswith("bar BAD!... /tmp…")]) == 1
     else:
         assert len([ln for ln in lines if ln.endswith("foo U       /tmp/")]) == 1
         assert len([ln for ln in lines if ln.endswith("bar BAD!... /tmp/")]) == 1

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -1160,4 +1160,6 @@ def test_tabular_shrinking_summary():
     out({"name": "foo", "status": "ok"})
 
     lines = fd.getvalue().splitlines()
-    assert len([ln for ln in lines if ln.startswith(unicode_cap("ed"))]) == 1
+    # Two summary lines shrank to one, so we expect a two move-ups and a clear.
+    expected = unicode_cap("cuu1") * 2 + unicode_cap("ed")
+    assert len([ln for ln in lines if ln.startswith(expected)]) == 1

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -383,6 +383,24 @@ def test_tabular_rewrite():
 
 
 @patch("pyout.tabular.Terminal", TestTerminal)
+def test_tabular_rewrite_with_header():
+    fd = StringIO()
+    out = Tabular(["name", "status"],
+                  style={"header_": {},
+                         "status": {"width": 9}},
+                  stream=fd, force_styling=True)
+    data = [{"name": "foo", "status": "unknown"},
+            {"name": "bar", "status": "unknown"}]
+    for row in data:
+        out(row)
+    out({"name": "bar", "status": "installed"})
+
+    expected = unicode_cap("cuu1") * 1 + unicode_cap("el") + "bar  installed"
+    assert eq_repr(fd.getvalue().strip().splitlines()[-1],
+                   expected)
+
+
+@patch("pyout.tabular.Terminal", TestTerminal)
 def test_tabular_rewrite_multi_id():
     fd = StringIO()
     out = Tabular(["name", "type", "status"],

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -1096,12 +1096,13 @@ def test_tabular_summary():
     def nbad(xs):
         return "{:d} failed".format(sum("BAD" == x for x in xs))
 
-    out = Tabular(style={"status": {"aggregate": nbad},
+    out = Tabular(style={"header_": {},
+                         "status": {"aggregate": nbad},
                          "num": {"aggregate": sum}},
                   stream=fd)
 
     out(OrderedDict([("name", "foo"),
-                     ("status", "OK"),
+                     ("status", "BAD"),
                      ("num", 2)]))
     out(OrderedDict([("name", "bar"),
                      ("status", "BAD"),
@@ -1110,7 +1111,13 @@ def test_tabular_summary():
                      ("status", "BAD"),
                      ("num", 4)]))
 
-    lines = fd.getvalue().splitlines()            #foo
-    assert len([ln for ln in lines if ln.endswith("    0 failed 2")]) == 1
-    assert len([ln for ln in lines if ln.endswith("    1 failed 5")]) == 1
-    assert len([ln for ln in lines if ln.endswith("    2 failed 9")]) == 1
+    # Update "foo".
+    out(OrderedDict([("name", "foo"),
+                     ("status", "OK"),
+                     ("num", 10)]))
+
+    lines = fd.getvalue().splitlines()            #name         #num
+    assert len([ln for ln in lines if ln.endswith("     1 failed 2  ")]) == 1
+    assert len([ln for ln in lines if ln.endswith("     2 failed 5  ")]) == 1
+    assert len([ln for ln in lines if ln.endswith("     3 failed 9  ")]) == 1
+    assert len([ln for ln in lines if ln.endswith("     2 failed 17 ")]) == 1


### PR DESCRIPTION
The main commit of interest is 3ae077cc9ca5d5022a3a194c53bc08adb7ad04f4.

@yarikoptic, how do you feel about the "aggregate" name?  I chose it over "summary" for two reasons:

  * I like that it is a verb (in line with "transform").  As verbs goes, "summarize" would work, but "aggregate" came to mind because of pandas (of course we're limiting ourselves to one axis here...).

  * For the summary row styles, I added the special key "summary_" (consistent with "header_") and in that case "summary" and "summary_" seem confusingly close.

------------------------------------------------------------------------

And here's a quick demo:

```python
from collections import Counter
import time

from pyout import Tabular


def check():
    for idx, update in enumerate([{"items": 2},
                                  {"items": 20, "status": "bad"}]):
        time.sleep(idx + 0.5)
        yield update


def counts(values):
    return ["Status"] + [" {}: {:d}".format(k, v)
                         for k, v in Counter(values).items()]


rows = [{"name": "abc", "items": 0, "status": "ok"},
        {"name": "abc00", ("items", "status"): check},
        {"name": "abc01", "items": 0, "status": "ok"},
        {"name": "abc02", "items": 3, "status": "ok"}]

style = {"summary_": {"bold": True},
         "items": {"aggregate": sum},
         "status": {"color": {"lookup": {"bad": "red"}},
                    "aggregate": counts}}

with Tabular(["name", "items", "status"], style=style) as out:
    for row in rows:
        out(row)

```
