### PR TITLE
BF: Truncate fields to avoid exceeding terminal width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ TODO Summary
   This feature can be used to provide a function that takes a field
   value and returns a transformed field value.
 
+- A new style attribute, "width_", has been added to the schema.
+
+  This determines the total width of the table, which is otherwise
+  take as the terminal's width.
+
 - Row values can now be generator functions or generator objects in
   addition to plain values and non-generator functions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ TODO Summary
 
 ### Deprecated
 ### Fixed
+
+- Rows that exceeded the terminal's width wrapped to the next line and
+  broke pyout's line counting logic (used to, e.g., update a previous
+  line).
+
 ### Removed
 ### Security
 

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -22,6 +22,7 @@ import six
 from pyout import elements
 from pyout.field import Field
 from pyout.field import Nothing
+from pyout.field import Truncater
 from pyout.summary import Summary
 
 lgr = getLogger(__name__)
@@ -316,14 +317,14 @@ class StyleFields(object):
                     lgr.debug("Setting max width of column %r to %d",
                               column, wmax)
                     marker = _safe_get(style_width, "marker", True)
-                    width_procs = [self.procgen.truncate(wmax, marker)]
+                    width_procs = [Truncater(wmax, marker).truncate]
             elif is_auto is False:
                 raise ValueError("No 'width' specified")
             else:
                 lgr.debug("Setting width of column %r to %d",
                           column, style_width)
                 width = style_width
-                width_procs = [self.procgen.truncate(width)]
+                width_procs = [Truncater(width).truncate]
 
             # We are creating a distinction between "width" processors, that we
             # always want to be active and "default" processors that we want to

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -268,6 +268,8 @@ class StyleFields(object):
         self.style["separator_"] = _safe_get(self.init_style, "separator_",
                                              elements.default("separator_"))
         lgr.debug("Validating style %r", self.style)
+        self.style["width_"] = _safe_get(self.init_style, "width_",
+                                         elements.default("width_"))
         elements.validate(self.style)
         self._setup_fields()
 

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -142,6 +142,12 @@ schema = {
             "description": "Separator used between fields",
             "type": "string",
             "default": " ",
+            "scope": "table"},
+        "width_": {
+            "description": """Total width of table.
+            This is typically not set directly by the user.""",
+            "default": 90,
+            "type": "integer",
             "scope": "table"}
     },
     # All other keys are column names.

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -174,13 +174,19 @@ def adopt(style, new_style):
 
 
 class StyleError(Exception):
-    """Exception raised for an invalid style.
+    """Style is invalid or mispecified in some way.
+    """
+    pass
+
+
+class StyleValidationError(StyleError):
+    """Exception raised if the style schema does not validate.
     """
     def __init__(self, original_exception):
         msg = ("Invalid style\n\n{}\n\n\n"
                "See pyout.schema for style definition."
                .format(original_exception))
-        super(StyleError, self).__init__(msg)
+        super(StyleValidationError, self).__init__(msg)
 
 
 def validate(style):
@@ -193,7 +199,7 @@ def validate(style):
 
     Raises
     ------
-    StyleError if `style` is not valid.
+    StyleValidationError if `style` is not valid.
     """
     try:
         import jsonschema
@@ -203,8 +209,8 @@ def validate(style):
     try:
         jsonschema.validate(style, schema)
     except jsonschema.ValidationError as exc:
-        new_exc = StyleError(exc)
+        new_exc = StyleValidationError(exc)
         # Don't dump the original jsonschema exception because it is already
-        # included in the StyleError's message.
+        # included in the StyleValidationError's message.
         new_exc.__cause__ = None
         raise new_exc

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -201,6 +201,43 @@ class StyleFunctionError(Exception):
         super(StyleFunctionError, self).__init__(msg)
 
 
+class Truncater(object):
+    """A processor that truncates the result to a given length.
+
+    Note: You probably want to place the `truncate` method at the beginning of
+    the processor list so that the truncation is based on the length of the
+    original value.
+
+    Parameters
+    ----------
+    length : int
+        Truncate the string to this length.
+    marker : str or bool
+        Indicate truncation with this string.  If True, indicate truncation by
+        replacing the last three characters of a truncated string with '...'.
+        If False, no truncation marker is added to a truncated string.
+    """
+
+    def __init__(self, length, marker=True):
+        self.length = length
+        self.marker = "..." if marker is True else marker
+
+    def truncate(self, _, result):
+        # TODO: Add an option to center the truncation marker?
+        length = self.length
+        marker = self.marker
+
+        if len(result) <= length:
+            return result
+        if marker:
+            marker_beg = max(length - len(marker), 0)
+            if result[marker_beg:].strip():
+                if marker_beg == 0:
+                    return marker[:length]
+                return result[:marker_beg] + marker
+        return result[:length]
+
+
 class StyleProcessors(object):
     """A base class for generating Field.processors for styled output.
 
@@ -230,43 +267,6 @@ class StyleProcessors(object):
         An output-specific styling of `value` (str).
         """
         raise NotImplementedError
-
-    @staticmethod
-    def truncate(length, marker=True):
-        """Return a processor that truncates the result to `length`.
-
-        Note: You probably want to place this function at the beginning of the
-        processor list so that the truncation is based on the length of the
-        original value.
-
-        Parameters
-        ----------
-        length : int
-        marker : str or bool
-            Indicate truncation with this string.  If True, indicate truncation
-            by replacing the last three characters of a truncated string with
-            '...'.  If False, no truncation marker is added to a truncated
-            string.
-
-        Returns
-        -------
-        A function.
-        """
-        if marker is True:
-            marker = "..."
-
-        # TODO: Add an option to center the truncation marker?
-        def truncate_fn(_, result):
-            if len(result) <= length:
-                return result
-            if marker:
-                marker_beg = max(length - len(marker), 0)
-                if result[marker_beg:].strip():
-                    if marker_beg == 0:
-                        return marker[:length]
-                    return result[:marker_beg] + marker
-            return result[:length]
-        return truncate_fn
 
     @staticmethod
     def transform(function):

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -80,6 +80,10 @@ class Tabular(object):
         self._columns = columns
         self._ids = None
 
+        style = style or {}
+        if "width_" not in style and self.term.width:
+            style["width_"] = self.term.width
+
         self._content = ContentWithSummary(
             StyleFields(style, TermProcessors(self.term)))
         self._last_content_len = 0
@@ -150,10 +154,6 @@ class Tabular(object):
                 # Clear the summary because 1) it has very likely changed, 2)
                 # it makes the counting for row updates simpler, 3) and it is
                 # possible for the summary lines to shrink.
-                #
-                # FIXME: This, like other line counting-based modifications in
-                # pyout, will fail if there is any line wrapping.  We need to
-                # detect the terminal width and somehow handle this.
                 lgr.debug("Clearing summary")
                 self._clear_last_summary()
             content, status, summary = self._content.update(row, style)

--- a/pyout/tests/test_elements.py
+++ b/pyout/tests/test_elements.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import pytest
 
 from pyout.elements import adopt
-from pyout.elements import StyleError
+from pyout.elements import StyleValidationError
 from pyout.elements import validate
 
 
@@ -49,7 +49,7 @@ def test_adopt():
 
 def test_validate_error():
     pytest.importorskip("jsonschema")
-    with pytest.raises(StyleError):
+    with pytest.raises(StyleValidationError):
         validate("not ok")
 
 

--- a/pyout/tests/test_field.py
+++ b/pyout/tests/test_field.py
@@ -8,6 +8,7 @@ import six
 from pyout.field import Field
 from pyout.field import Nothing
 from pyout.field import StyleProcessors
+from pyout.field import Truncater
 
 
 def test_field_base():
@@ -58,7 +59,7 @@ def test_something_about_nothing(text):
 
 
 def test_truncate_mark_true():
-    fn = StyleProcessors.truncate(7, marker=True)
+    fn = Truncater(7, marker=True).truncate
 
     assert fn(None, "abc") == "abc"
     assert fn(None, "abcdefg") == "abcdefg"
@@ -66,7 +67,7 @@ def test_truncate_mark_true():
 
 
 def test_truncate_mark_string():
-    fn = StyleProcessors.truncate(7, marker="…")
+    fn = Truncater(7, marker="…").truncate
 
     assert fn(None, "abc") == "abc"
     assert fn(None, "abcdefg") == "abcdefg"
@@ -74,12 +75,12 @@ def test_truncate_mark_string():
 
 
 def test_truncate_mark_short():
-    fn = StyleProcessors.truncate(2, marker=True)
+    fn = Truncater(2, marker=True).truncate
     assert fn(None, "abc") == ".."
 
 
 def test_truncate_nomark():
-    fn = StyleProcessors.truncate(7, marker=False)
+    fn = Truncater(7, marker=False).truncate
 
     assert fn(None, "abc") == "abc"
     assert fn(None, "abcdefg") == "abcdefg"

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -23,10 +23,12 @@ from pyout.field import StyleFunctionError
 from pyout.tests.utils import assert_contains
 from pyout.tests.utils import assert_eq_repr
 
-# TestTerminal, unicode_cap, and unicode_parm are copied from
-# blessings' tests.
 
-TestTerminal = partial(blessings.Terminal, kind='xterm-256color')
+class Terminal(blessings.Terminal):
+
+    def __init__(self, *args, **kwargs):
+        super(Terminal, self).__init__(
+            *args, kind="xterm-256color", **kwargs)
 
 
 class Tabular(TheRealTabular):
@@ -35,13 +37,16 @@ class Tabular(TheRealTabular):
 
     def __init__(self, *args, **kwargs):
         fd = StringIO()
-        with patch("pyout.tabular.Terminal", TestTerminal):
+        with patch("pyout.tabular.Terminal", Terminal):
             super(Tabular, self).__init__(
                 *args, force_styling=True, stream=fd, **kwargs)
 
     @property
     def stdout(self):
         return self.term.stream.getvalue()
+
+
+# unicode_cap, and unicode_parm are copied from blessings' tests.
 
 
 def unicode_cap(cap):


### PR DESCRIPTION
```
If the width of a row exceeds the terminal's width, it wraps into the
next line and breaks all of our line counting-based modifications.  To
deal with this, we need truncate fields so that the row is within the
available width.  Note that we can't simply truncate at the row-level
because each field by include escape sequences.
```