### PR TITLE
 BF: interface: Prevent callbacks trying to update offscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- The output was corrupted when a callback function tried to update a
+  line that was no longer visible on the screen.
+
 - When a table did not include a summary, "incremental" and "final"
   mode added "None" as the last row.
 

--- a/pyout/interface.py
+++ b/pyout/interface.py
@@ -193,12 +193,34 @@ class Writer(object):
             # possible for the summary lines to shrink.
             lgr.debug("Clearing summary")
             self._stream.clear_last_lines(last_summary_len)
-        content, status, summary = self._content.update(row, style)
-        if isinstance(status, int):
-            lgr.debug("Overwriting line %d with %r", status, row)
-            self._stream.overwrite_line(self._last_content_len - status,
-                                        content)
         else:
+            last_summary_len = 0
+
+        content, status, summary = self._content.update(row, style)
+
+        single_row_updated = False
+        if isinstance(status, int):
+            height = self._stream.height
+            if height is None:  # non-tty
+                n_visible = self._last_content_len
+            else:
+                n_visible = min(
+                    height - last_summary_len - 1,  # -1 for current line.
+                    self._last_content_len)
+
+            n_back = self._last_content_len - status
+            if n_back > n_visible:
+                lgr.debug("Cannot move back %d rows for update; "
+                          "only %d visible rows",
+                          n_back, n_visible)
+                status = "repaint"
+                content = six.text_type(self._content)
+            else:
+                lgr.debug("Overwriting line %d with %r", status, row)
+                self._stream.overwrite_line(n_back, content)
+                single_row_updated = True
+
+        if not single_row_updated:
             if status == "repaint":
                 lgr.debug("Repainting the whole thing.  Blame row %r", row)
                 self._stream.move_to(self._last_content_len)

--- a/pyout/interface.py
+++ b/pyout/interface.py
@@ -30,6 +30,9 @@ class Stream(object):
     def width(self):
         """Maximum line width.
         """
+    @abc.abstractproperty
+    def height(self):
+        """Maximum number of rows that are visible."""
 
     @abc.abstractmethod
     def write(self, text):

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -24,12 +24,19 @@ class TerminalStream(interface.Stream):
 
     def __init__(self):
         self.term = Terminal()
+        self._height = self.term.height
 
     @property
     def width(self):
         """Maximum terminal width.
         """
         return self.term.width
+
+    @property
+    def height(self):
+        """Terminal height.
+        """
+        return self._height
 
     def write(self, text):
         """Write `text` to terminal.

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -42,13 +42,31 @@ class Terminal(blessings.Terminal):
         return 20
 
 
+class TerminalNonInteractive(Terminal):
+
+    @property
+    def width(self):
+        return None
+
+    @property
+    def height(self):
+        return None
+
+
 class Tabular(TheRealTabular):
     """Test-specific subclass of pyout.Tabular.
     """
 
     def __init__(self, *args, **kwargs):
-        with patch("pyout.interface.sys.stdout.isatty", return_value=True):
-            with patch("pyout.tabular.Terminal", Terminal):
+        interactive = kwargs.pop("interactive", True)
+        if interactive:
+            term = Terminal
+        else:
+            term = TerminalNonInteractive
+
+        with patch("pyout.interface.sys.stdout.isatty",
+                   return_value=interactive):
+            with patch("pyout.tabular.Terminal", term):
                 super(Tabular, self).__init__(*args, **kwargs)
 
     @property

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -920,6 +920,17 @@ def test_tabular_write_callable_values_multi_return():
 @pytest.mark.parametrize("nrows", [20, 21])
 @pytest.mark.parametrize("interactive", [True, False])
 def test_tabular_callback_to_hidden_row(nrows, interactive):
+    if sys.version_info < (3,):
+        try:
+            import jsonschema
+        except ImportError:
+            pass
+        else:
+            # Ideally we'd also check if the tests are running under
+            # coverage, but I don't know a way to do that.
+            pytest.xfail(
+                "Hangs for unknown reason in py2/coverage/jsonschema run")
+
     delay = Delayed("OK")
     out = Tabular(interactive=interactive,
                   style={"status": {"aggregate": len}})

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -37,6 +37,10 @@ class Terminal(blessings.Terminal):
     def width(self):
         return 100
 
+    @property
+    def height(self):
+        return 20
+
 
 class Tabular(TheRealTabular):
     """Test-specific subclass of pyout.Tabular.


### PR DESCRIPTION
This PR fixes #42 by implementing the repaint solution proposed [here](https://github.com/pyout/pyout/issues/42#issuecomment-446732802).

Using the `datalad ls` command from #42 with cleared caches, I didn't observe the issue after applying these changes (or more accurately, an earlier version of the changes: f4e40f677e489a).