### PR TITLE
ENH: Support left and center truncation styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 
+### Added
+
+- A fixed width could be specified by setting the "width" style
+  attribute to an integer, but there was previously no way to specify
+  the truncation marker.  A "width" key is now accepted in the
+  dictionary form (e.g., `{"width": 10, "marker": "…"}`).
+
 ### Fixed
 
 - The output was corrupted when a callback function tried to update a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   the truncation marker.  A "width" key is now accepted in the
   dictionary form (e.g., `{"width": 10, "marker": "…"}`).
 
+- The "width" style attribute now supports a "truncate" key that can
+  be "left", "center", or "right" (e.g., `{"width": {"truncate":
+  "left"}}}`).
+
 ### Changed
 
 - When giving a dictionary as the "width" style attribute's value, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   the truncation marker.  A "width" key is now accepted in the
   dictionary form (e.g., `{"width": 10, "marker": "…"}`).
 
+### Changed
+
+- When giving a dictionary as the "width" style attribute's value, the
+  "auto" key is no longer supported because the appropriate behavior
+  can be inferred from the "min", "max", and "width" keys.
+
 ### Fixed
 
 - The output was corrupted when a callback function tried to update a

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -22,7 +22,7 @@ import six
 from pyout import elements
 from pyout.field import Field
 from pyout.field import Nothing
-from pyout.field import Truncater
+from pyout.truncate import Truncater
 from pyout.summary import Summary
 
 lgr = getLogger(__name__)

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -309,7 +309,14 @@ class StyleFields(object):
             lgr.debug("Setting up field for column %r", column)
             cstyle = self.style[column]
             style_width = cstyle["width"]
-            is_auto = style_width == "auto" or _safe_get(style_width, "auto")
+
+            # Convert atomic values into the equivalent complex form.
+            if style_width == "auto":
+                style_width = {"auto": True}
+            elif isinstance(style_width, int):
+                style_width = {"width": style_width, "auto": False}
+
+            is_auto = style_width.get("auto", True)
             if is_auto:
                 width = _safe_get(style_width, "min", 0)
                 wmax = _safe_get(style_width, "max")
@@ -317,12 +324,12 @@ class StyleFields(object):
                 if wmax is not None:
                     lgr.debug("Setting max width of column %r to %d",
                               column, wmax)
-            elif is_auto is False:
+            elif is_auto is False and "width" not in style_width:
                 raise ValueError("No 'width' specified")
             else:
+                width = style_width["width"]
                 lgr.debug("Setting width of column %r to %d",
-                          column, style_width)
-                width = style_width
+                          column, width)
 
             # We are creating a distinction between "width" processors, that we
             # always want to be active and "default" processors that we want to

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -312,21 +312,23 @@ class StyleFields(object):
 
             # Convert atomic values into the equivalent complex form.
             if style_width == "auto":
-                style_width = {"auto": True}
+                style_width = {}
             elif isinstance(style_width, int):
-                style_width = {"width": style_width, "auto": False}
+                style_width = {"width": style_width}
 
-            is_auto = style_width.get("auto", True)
+            is_auto = "width" not in style_width
             if is_auto:
+                lgr.debug("Automatically adjusting width for %s", column)
                 width = _safe_get(style_width, "min", 0)
                 wmax = _safe_get(style_width, "max")
                 self.autowidth_columns[column] = {"max": wmax}
                 if wmax is not None:
                     lgr.debug("Setting max width of column %r to %d",
                               column, wmax)
-            elif is_auto is False and "width" not in style_width:
-                raise ValueError("No 'width' specified")
             else:
+                if "min" in style_width or "max" in style_width:
+                    raise ValueError(
+                        "'min' and 'max' are incompatible with 'width'")
                 width = style_width["width"]
                 lgr.debug("Setting width of column %r to %d",
                           column, width)

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -342,8 +342,10 @@ class StyleFields(object):
                           other_keys=["override"])
             field.add("pre", "default",
                       *(self.procgen.pre_from_style(cstyle)))
-            truncater = Truncater(width,
-                                  _safe_get(style_width, "marker", True))
+            truncater = Truncater(
+                width,
+                _safe_get(style_width, "marker", True),
+                _safe_get(style_width, "truncate", "right"))
             field.add("post", "width", truncater.truncate)
             field.add("post", "default",
                       *(self.procgen.post_from_style(cstyle)))

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -46,7 +46,8 @@ schema = {
                        "properties": {
                            "auto": {"type": "boolean"},
                            "max": {"type": ["integer", "null"]},
-                           "min": {"type": ["integer", "null"]}}}],
+                           "min": {"type": ["integer", "null"]},
+                           "marker": {"type": ["string", "boolean"]}}}],
             "default": "auto",
             "scope": "column"},
         # Other style elements

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -46,7 +46,9 @@ schema = {
             object can be specified.  Its 'min' and 'max' keys specify the
             minimum and maximum widths allowed, whereas the 'width' key
             specifies a fixed width.  The 'marker' key specifies the marker
-            used for truncation ('...' by default).""",
+            used for truncation ('...' by default).  Where the field is
+            truncated can be configured with 'truncate': 'right' (default),
+            'left', or 'center.""",
             "oneOf": [{"type": "integer"},
                       {"type": "string",
                        "enum": ["auto"]},
@@ -55,7 +57,11 @@ schema = {
                            "max": {"type": ["integer", "null"]},
                            "min": {"type": ["integer", "null"]},
                            "width": {"type": "integer"},
-                           "marker": {"type": ["string", "boolean"]}},
+                           "marker": {"type": ["string", "boolean"]},
+                           "truncate": {"type": "string",
+                                           "enum": ["left",
+                                                    "right",
+                                                    "center"]}},
                        "additionalProperties": False}],
             "default": "auto",
             "scope": "column"},

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -38,7 +38,15 @@ schema = {
             "default": False,
             "scope": "field"},
         "width": {
-            "description": "Width of field",
+            "description": """Width of field.  With the default value, 'auto',
+            the column width is automatically adjusted to fit the content and
+            may be truncated to ensure that the entire row fits within the
+            available output width.  An integer value forces all fields in a
+            column to have a width of the specified value. In addition, an
+            object can be specified.  Its 'min' and 'max' keys specify the
+            minimum and maximum widths allowed, whereas the 'width' key
+            specifies a fixed width.  The 'marker' key specifies the marker
+            used for truncation ('...' by default).""",
             "oneOf": [{"type": "integer"},
                       {"type": "string",
                        "enum": ["auto"]},

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -44,7 +44,6 @@ schema = {
                        "enum": ["auto"]},
                       {"type": "object",
                        "properties": {
-                           "auto": {"type": "boolean"},
                            "max": {"type": ["integer", "null"]},
                            "min": {"type": ["integer", "null"]},
                            "width": {"type": "integer"},

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -47,6 +47,7 @@ schema = {
                            "auto": {"type": "boolean"},
                            "max": {"type": ["integer", "null"]},
                            "min": {"type": ["integer", "null"]},
+                           "width": {"type": "integer"},
                            "marker": {"type": ["string", "boolean"]}},
                        "additionalProperties": False}],
             "default": "auto",

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -47,7 +47,8 @@ schema = {
                            "auto": {"type": "boolean"},
                            "max": {"type": ["integer", "null"]},
                            "min": {"type": ["integer", "null"]},
-                           "marker": {"type": ["string", "boolean"]}}}],
+                           "marker": {"type": ["string", "boolean"]}},
+                       "additionalProperties": False}],
             "default": "auto",
             "scope": "column"},
         # Other style elements

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -212,7 +212,7 @@ class Truncater(object):
     ----------
     length : int
         Truncate the string to this length.
-    marker : str or bool
+    marker : str or bool, optional
         Indicate truncation with this string.  If True, indicate truncation by
         replacing the last three characters of a truncated string with '...'.
         If False, no truncation marker is added to a truncated string.

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -201,43 +201,6 @@ class StyleFunctionError(Exception):
         super(StyleFunctionError, self).__init__(msg)
 
 
-class Truncater(object):
-    """A processor that truncates the result to a given length.
-
-    Note: You probably want to place the `truncate` method at the beginning of
-    the processor list so that the truncation is based on the length of the
-    original value.
-
-    Parameters
-    ----------
-    length : int
-        Truncate the string to this length.
-    marker : str or bool, optional
-        Indicate truncation with this string.  If True, indicate truncation by
-        replacing the last three characters of a truncated string with '...'.
-        If False, no truncation marker is added to a truncated string.
-    """
-
-    def __init__(self, length, marker=True):
-        self.length = length
-        self.marker = "..." if marker is True else marker
-
-    def truncate(self, _, result):
-        # TODO: Add an option to center the truncation marker?
-        length = self.length
-        marker = self.marker
-
-        if len(result) <= length:
-            return result
-        if marker:
-            marker_beg = max(length - len(marker), 0)
-            if result[marker_beg:].strip():
-                if marker_beg == 0:
-                    return marker[:length]
-                return result[:marker_beg] + marker
-        return result[:length]
-
-
 class StyleProcessors(object):
     """A base class for generating Field.processors for styled output.
 

--- a/pyout/tests/test_field.py
+++ b/pyout/tests/test_field.py
@@ -8,7 +8,6 @@ import six
 from pyout.field import Field
 from pyout.field import Nothing
 from pyout.field import StyleProcessors
-from pyout.field import Truncater
 
 
 def test_field_base():
@@ -56,35 +55,6 @@ def test_something_about_nothing(text):
     assert "{:5}".format(nada) == "{:5}".format(text)
     assert "x" + nada == "x" + text
     assert nada + "x" == text + "x"
-
-
-def test_truncate_mark_true():
-    fn = Truncater(7, marker=True).truncate
-
-    assert fn(None, "abc") == "abc"
-    assert fn(None, "abcdefg") == "abcdefg"
-    assert fn(None, "abcdefgh") == "abcd..."
-
-
-def test_truncate_mark_string():
-    fn = Truncater(7, marker="…").truncate
-
-    assert fn(None, "abc") == "abc"
-    assert fn(None, "abcdefg") == "abcdefg"
-    assert fn(None, "abcdefgh") == "abcdef…"
-
-
-def test_truncate_mark_short():
-    fn = Truncater(2, marker=True).truncate
-    assert fn(None, "abc") == ".."
-
-
-def test_truncate_nomark():
-    fn = Truncater(7, marker=False).truncate
-
-    assert fn(None, "abc") == "abc"
-    assert fn(None, "abcdefg") == "abcdefg"
-    assert fn(None, "abcdefgh") == "abcdefg"
 
 
 def test_style_value_type():

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -703,7 +703,7 @@ def test_tabular_write_autowidth_with_header():
 
 def test_tabular_write_autowidth_min():
     out = Tabular(style={"name": {"width": "auto"},
-                         "status": {"width": {"auto": True, "min": 5}},
+                         "status": {"width": {"min": 5}},
                          "path": {"width": 6}})
     out(OrderedDict([("name", "fooab"),
                      ("status", "OK"),
@@ -721,8 +721,8 @@ def test_tabular_write_autowidth_min():
 def test_tabular_write_autowidth_min_max(marker):
     out = Tabular(style={"name": {"width": 3},
                          "status": {"width":
-                                    {"auto": True, "min": 2, "max": 7}},
-                         "path": {"width": {"auto": True, "max": 5,
+                                    {"min": 2, "max": 7}},
+                         "path": {"width": {"max": 5,
                                             "marker": marker}}})
     out(OrderedDict([("name", "foo"),
                      ("status", "U"),
@@ -758,7 +758,7 @@ def test_tabular_write_autowidth_min_max_with_header():
     out = Tabular(style={"header_": {},
                          "name": {"width": 4},
                          "status": {"width":
-                                    {"auto": True, "min": 2, "max": 8}}})
+                                    {"min": 2, "max": 8}}})
     out(OrderedDict([("name", "foo"),
                      ("status", "U")]))
 
@@ -777,7 +777,7 @@ def test_tabular_write_autowidth_different_data_types_same_output():
                        style={"header_": {},
                               "name": {"width": 4},
                               "status": {"width":
-                                         {"auto": True, "min": 2, "max": 8}}})
+                                         {"min": 2, "max": 8}}})
     out_dict({"name": "foo", "status": "U"})
     out_dict({"name": "bar", "status": "BAD!!!!!!!!!!!"})
 
@@ -785,17 +785,17 @@ def test_tabular_write_autowidth_different_data_types_same_output():
                        style={"header_": {},
                               "name": {"width": 4},
                               "status": {"width":
-                                         {"auto": True, "min": 2, "max": 8}}})
+                                         {"min": 2, "max": 8}}})
     out_list(["foo", "U"])
     out_list(["bar", "BAD!!!!!!!!!!!"])
 
     assert out_dict.stdout == out_list.stdout
 
 
-def test_tabular_write_autowidth_auto_false_exception():
+def test_tabular_write_incompatible_width_exception():
     out = Tabular(style={"header_": {},
-                         "name": {"width": 4},
-                         "status": {"width": {"auto": False}}})
+                         "status": {"width": {"min": 4,
+                                              "width": 9}}})
     with pytest.raises(ValueError):
         out(OrderedDict([("name", "foo"),
                          ("status", "U")]))

--- a/pyout/tests/test_truncate.py
+++ b/pyout/tests/test_truncate.py
@@ -28,22 +28,49 @@ def test_truncate_mark_true():
     assert fn(None, "abcdefgh") == "abcd..."
 
 
-def test_truncate_mark_string():
-    fn = Truncater(7, marker="…").truncate
+@pytest.mark.parametrize("where", ["left", "center", "right"])
+def test_truncate_mark_string(where):
+    fn = Truncater(7, marker="…", where=where).truncate
 
     assert fn(None, "abc") == "abc"
     assert fn(None, "abcdefg") == "abcdefg"
-    assert fn(None, "abcdefgh") == "abcdef…"
+
+    expected = {"left": "…cdefgh",
+                "center": "abc…fgh",
+                "right": "abcdef…"}
+    assert fn(None, "abcdefgh") == expected[where]
 
 
-def test_truncate_mark_short():
-    fn = Truncater(2, marker=True).truncate
+@pytest.mark.parametrize("where", ["left", "center", "right"])
+def test_truncate_mark_even(where):
+    # Test out a marker with an even number of characters, mostly to get the
+    # "center" style on seven characters to be uneven.
+    fn = Truncater(7, marker="..", where=where).truncate
+    expected = {"left": "..defgh",
+                "center": "ab..fgh",
+                "right": "abcde.."}
+    assert fn(None, "abcdefgh") == expected[where]
+
+
+@pytest.mark.parametrize("where", ["left", "center", "right"])
+def test_truncate_mark_short(where):
+    fn = Truncater(2, marker=True, where=where).truncate
     assert fn(None, "abc") == ".."
 
 
-def test_truncate_nomark():
-    fn = Truncater(7, marker=False).truncate
+@pytest.mark.parametrize("where", ["left", "center", "right"])
+def test_truncate_nomark(where):
+    fn = Truncater(7, marker=False, where=where).truncate
 
     assert fn(None, "abc") == "abc"
     assert fn(None, "abcdefg") == "abcdefg"
-    assert fn(None, "abcdefgh") == "abcdefg"
+
+    expected = {"left": "bcdefgh",
+                "center": "abcefgh",
+                "right": "abcdefg"}
+    assert fn(None, "abcdefgh") == expected[where]
+
+
+def test_truncate_unknown_where():
+    with pytest.raises(ValueError):
+        Truncater(7, marker=False, where="dunno")

--- a/pyout/tests/test_truncate.py
+++ b/pyout/tests/test_truncate.py
@@ -2,7 +2,22 @@
 
 from __future__ import unicode_literals
 
+import pytest
+
+from pyout.truncate import _splice as splice
 from pyout.truncate import Truncater
+
+
+def test_splice_non_positive():
+    with pytest.raises(ValueError):
+        assert splice("", 0)
+
+
+def test_splice():
+    assert splice("", 10) == ("", "")
+    assert splice("abc", 10) == ("a", "bc")
+    assert splice("abc", 3) == ("a", "bc")
+    assert splice("abcefg", 3) == ("a", "fg")
 
 
 def test_truncate_mark_true():

--- a/pyout/tests/test_truncate.py
+++ b/pyout/tests/test_truncate.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from pyout.truncate import Truncater
+
+
+def test_truncate_mark_true():
+    fn = Truncater(7, marker=True).truncate
+
+    assert fn(None, "abc") == "abc"
+    assert fn(None, "abcdefg") == "abcdefg"
+    assert fn(None, "abcdefgh") == "abcd..."
+
+
+def test_truncate_mark_string():
+    fn = Truncater(7, marker="…").truncate
+
+    assert fn(None, "abc") == "abc"
+    assert fn(None, "abcdefg") == "abcdefg"
+    assert fn(None, "abcdefgh") == "abcdef…"
+
+
+def test_truncate_mark_short():
+    fn = Truncater(2, marker=True).truncate
+    assert fn(None, "abc") == ".."
+
+
+def test_truncate_nomark():
+    fn = Truncater(7, marker=False).truncate
+
+    assert fn(None, "abc") == "abc"
+    assert fn(None, "abcdefg") == "abcdefg"
+    assert fn(None, "abcdefgh") == "abcdefg"

--- a/pyout/truncate.py
+++ b/pyout/truncate.py
@@ -86,12 +86,21 @@ class Truncater(object):
         Indicate truncation with this string.  If True, indicate truncation by
         replacing the last three characters of a truncated string with '...'.
         If False, no truncation marker is added to a truncated string.
+    where : {'left', 'center', 'right'}, optional
+        Where to truncate the result.
     """
 
-    def __init__(self, length, marker=True):
+    def __init__(self, length, marker=True, where="right"):
         self.length = length
         self.marker = "..." if marker is True else marker
-        self._truncate_fn = _truncate_right
+
+        truncate_fns = {"left": _truncate_left,
+                        "center": _truncate_center,
+                        "right": _truncate_right}
+        try:
+            self._truncate_fn = truncate_fns[where]
+        except KeyError:
+            raise ValueError("Unrecognized `where` value: {}".format(where))
 
     def truncate(self, _, result):
         return self._truncate_fn(result, self.length, self.marker)

--- a/pyout/truncate.py
+++ b/pyout/truncate.py
@@ -4,6 +4,18 @@
 from __future__ import unicode_literals
 
 
+def _truncate_right(value, length, marker):
+    if len(value) <= length:
+        return value
+    if marker:
+        marker_beg = max(length - len(marker), 0)
+        if value[marker_beg:].strip():
+            if marker_beg == 0:
+                return marker[:length]
+            return value[:marker_beg] + marker
+    return value[:length]
+
+
 class Truncater(object):
     """A processor that truncates the result to a given length.
 
@@ -24,18 +36,7 @@ class Truncater(object):
     def __init__(self, length, marker=True):
         self.length = length
         self.marker = "..." if marker is True else marker
+        self._truncate_fn = _truncate_right
 
     def truncate(self, _, result):
-        # TODO: Add an option to center the truncation marker?
-        length = self.length
-        marker = self.marker
-
-        if len(result) <= length:
-            return result
-        if marker:
-            marker_beg = max(length - len(marker), 0)
-            if result[marker_beg:].strip():
-                if marker_beg == 0:
-                    return marker[:length]
-                return result[:marker_beg] + marker
-        return result[:length]
+        return self._truncate_fn(result, self.length, self.marker)

--- a/pyout/truncate.py
+++ b/pyout/truncate.py
@@ -6,14 +6,16 @@ from __future__ import unicode_literals
 
 def _truncate_right(value, length, marker):
     if len(value) <= length:
-        return value
-    if marker:
-        marker_beg = max(length - len(marker), 0)
-        if value[marker_beg:].strip():
-            if marker_beg == 0:
-                return marker[:length]
-            return value[:marker_beg] + marker
-    return value[:length]
+        short = value
+    elif marker:
+        nchars_free = length - len(marker)
+        if nchars_free > 0:
+            short = value[:nchars_free] + marker
+        else:
+            short = marker[:length]
+    else:
+        short = value[:length]
+    return short
 
 
 class Truncater(object):

--- a/pyout/truncate.py
+++ b/pyout/truncate.py
@@ -24,6 +24,36 @@ def _truncate_left(value, length, marker):
     return res[::-1]
 
 
+def _splice(value, n):
+    """Splice `value` at its center, retaining a total of `n` characters.
+
+    Parameters
+    ----------
+    value : str
+    n : int
+        The total length of the returned ends will not be greater than this
+        value.  Characters will be dropped from the center to reach this limit.
+
+    Returns
+    -------
+    A tuple of str: (head, tail).
+    """
+    if n <= 0:
+        raise ValueError("n must be positive")
+
+    value_len = len(value)
+    center = value_len // 2
+    left, right = value[:center], value[center:]
+
+    if n >= value_len:
+        return left, right
+
+    n_todrop = value_len - n
+    right_idx = n_todrop // 2
+    left_idx = right_idx + n_todrop % 2
+    return left[:-left_idx], right[right_idx:]
+
+
 class Truncater(object):
     """A processor that truncates the result to a given length.
 

--- a/pyout/truncate.py
+++ b/pyout/truncate.py
@@ -1,0 +1,41 @@
+"""Processor for field value truncation.
+"""
+
+from __future__ import unicode_literals
+
+
+class Truncater(object):
+    """A processor that truncates the result to a given length.
+
+    Note: You probably want to place the `truncate` method at the beginning of
+    the processor list so that the truncation is based on the length of the
+    original value.
+
+    Parameters
+    ----------
+    length : int
+        Truncate the string to this length.
+    marker : str or bool, optional
+        Indicate truncation with this string.  If True, indicate truncation by
+        replacing the last three characters of a truncated string with '...'.
+        If False, no truncation marker is added to a truncated string.
+    """
+
+    def __init__(self, length, marker=True):
+        self.length = length
+        self.marker = "..." if marker is True else marker
+
+    def truncate(self, _, result):
+        # TODO: Add an option to center the truncation marker?
+        length = self.length
+        marker = self.marker
+
+        if len(result) <= length:
+            return result
+        if marker:
+            marker_beg = max(length - len(marker), 0)
+            if result[marker_beg:].strip():
+                if marker_beg == 0:
+                    return marker[:length]
+                return result[:marker_beg] + marker
+        return result[:length]

--- a/pyout/truncate.py
+++ b/pyout/truncate.py
@@ -54,6 +54,23 @@ def _splice(value, n):
     return left[:-left_idx], right[right_idx:]
 
 
+def _truncate_center(value, length, marker):
+    value_len = len(value)
+    if value_len <= length:
+        return value
+
+    if marker:
+        marker_len = len(marker)
+        if marker_len < length:
+            left, right = _splice(value, length - marker_len)
+            parts = left, marker, right
+        else:
+            parts = _splice(marker, length)
+    else:
+        parts = _splice(value, length)
+    return "".join(parts)
+
+
 class Truncater(object):
     """A processor that truncates the result to a given length.
 

--- a/pyout/truncate.py
+++ b/pyout/truncate.py
@@ -18,6 +18,12 @@ def _truncate_right(value, length, marker):
     return short
 
 
+def _truncate_left(value, length, marker):
+    res = _truncate_right(value[::-1], length,
+                          marker[::-1] if marker else None)
+    return res[::-1]
+
+
 class Truncater(object):
     """A processor that truncates the result to a given length.
 


### PR DESCRIPTION
Support specifying the truncation style with `<col>: {"width": {"truncate_at": VAL}`, where VAL is "left", "center", or "right".

Any other ideas for the key name instead of "truncate_at"?