### PR TITLE
NF: Support styling values based on regular expression matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- The new style attribute "re_lookup" adds support for styling a value
+  when it matches a regular expression.
+
 ## [0.3.0] - 2018-12-18
 
 ### Added

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -18,6 +18,7 @@ schema = {
             "description": "Whether text is bold",
             "oneOf": [{"type": "boolean"},
                       {"$ref": "#/definitions/lookup"},
+                      {"$ref": "#/definitions/re_lookup"},
                       {"$ref": "#/definitions/interval"}],
             "default": False,
             "scope": "field"},
@@ -27,6 +28,7 @@ schema = {
                        "enum": ["black", "red", "green", "yellow",
                                 "blue", "magenta", "cyan", "white"]},
                       {"$ref": "#/definitions/lookup"},
+                      {"$ref": "#/definitions/re_lookup"},
                       {"$ref": "#/definitions/interval"}],
             "default": "black",
             "scope": "field"},
@@ -34,6 +36,7 @@ schema = {
             "description": "Whether text is underlined",
             "oneOf": [{"type": "boolean"},
                       {"$ref": "#/definitions/lookup"},
+                      {"$ref": "#/definitions/re_lookup"},
                       {"$ref": "#/definitions/interval"}],
             "default": False,
             "scope": "field"},
@@ -123,7 +126,20 @@ schema = {
             "description": "Map a value to a style",
             "type": "object",
             "properties": {"lookup": {"type": "object"}},
-            "additionalProperties": False}
+            "additionalProperties": False},
+        "re_lookup": {
+            "description": """Apply a style to values that match a regular
+            expression.  The regular expressions are matched with re.search and
+            tried in order, stopping after the first match.""",
+            "type": "object",
+            "properties": {"re_lookup":
+                           {"type": "array",
+                            "items": [
+                                {"type": "array",
+                                 "items": [{"type": "string"},
+                                           {"type": ["string", "boolean"]}],
+                                 "additionalItems": False}]}},
+            "additionalProperties": False},
     },
     "type": "object",
     "properties": {
@@ -247,12 +263,12 @@ def value_type(value):
 
     Returns
     -------
-    str, {"simple", "lookup", "interval"}
+    str, {"simple", "lookup", "re_lookup", "interval"}
     """
     try:
         keys = list(value.keys())
     except AttributeError:
         return "simple"
-    if keys in [["lookup"], ["interval"]]:
+    if keys in [["lookup"], ["re_lookup"], ["interval"]]:
         return keys[0]
     raise ValueError("Type of `value` could not be determined")

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -89,6 +89,15 @@ schema = {
             "default": "",
             "scope": "column"
         },
+        "re_flags": {
+            "description": """Flags passed to re.search when using re_lookup.
+            See the documentation of the re module for a description of
+            possible values.  'I' (ignore case) is the most likely value of
+            interest.""",
+            "type": "array",
+            "items": [{"type": "string",
+                       "enum": ["A", "I", "L", "M", "S", "U", "X"]}],
+            "scope": "field"},
         "transform": {
             "description": """An arbitrary function.
             This function will be called with the (unprocessed) field value as
@@ -105,6 +114,7 @@ schema = {
                            "color": {"$ref": "#/definitions/color"},
                            "delayed": {"$ref": "#/definitions/delayed"},
                            "missing": {"$ref": "#/definitions/missing"},
+                           "re_flags": {"$ref": "#/definitions/re_flags"},
                            "transform": {"$ref": "#/definitions/transform"},
                            "underline": {"$ref": "#/definitions/underline"},
                            "width": {"$ref": "#/definitions/width"}},
@@ -130,7 +140,8 @@ schema = {
         "re_lookup": {
             "description": """Apply a style to values that match a regular
             expression.  The regular expressions are matched with re.search and
-            tried in order, stopping after the first match.""",
+            tried in order, stopping after the first match.  Flags for
+            re.search can be specified via the re_flags style attribute.""",
             "type": "object",
             "properties": {"re_lookup":
                            {"type": "array",

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -319,7 +319,7 @@ class StyleProcessors(object):
             return self.render(style_attr or lookup_value, result)
         return proc
 
-    def by_re_lookup(self, style_key, style_value):
+    def by_re_lookup(self, style_key, style_value, re_flags=0):
         """Return a processor for a "re_lookup" style value.
 
         Parameters
@@ -332,13 +332,16 @@ class StyleProcessors(object):
             x)`, where regexp is a regular expression to match against the
             field value and x is either a style attribute (str) and a boolean
             flag indicating to use the style attribute named by `style_key`.
+        re_flags : int
+            Passed through as flags argument to re.compile.
 
         Returns
         -------
         A function.
         """
         style_attr = style_key if self.style_types[style_key] is bool else None
-        regexps = [(re.compile(r), v) for r, v in style_value["re_lookup"]]
+        regexps = [(re.compile(r, flags=re_flags), v)
+                   for r, v in style_value["re_lookup"]]
 
         def proc(value, result):
             for r, lookup_value in regexps:
@@ -434,6 +437,9 @@ class StyleProcessors(object):
             vtype = value_type(column_style[key])
             fn = fns[vtype]
             args = [key, column_style[key]]
+            if vtype == "re_lookup":
+                args.append(sum(getattr(re, f)
+                                for f in column_style.get("re_flags", [])))
             yield fn(*args)
 
         yield flanks.join_flanks

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -319,6 +319,36 @@ class StyleProcessors(object):
             return self.render(style_attr or lookup_value, result)
         return proc
 
+    def by_re_lookup(self, style_key, style_value):
+        """Return a processor for a "re_lookup" style value.
+
+        Parameters
+        ----------
+        style_key : str
+            A style key.
+        style_value : dict
+            A dictionary with a "re_lookup" style value that consists of a
+            sequence of items where each item should have the form `(regexp,
+            x)`, where regexp is a regular expression to match against the
+            field value and x is either a style attribute (str) and a boolean
+            flag indicating to use the style attribute named by `style_key`.
+
+        Returns
+        -------
+        A function.
+        """
+        style_attr = style_key if self.style_types[style_key] is bool else None
+        regexps = [(re.compile(r), v) for r, v in style_value["re_lookup"]]
+
+        def proc(value, result):
+            for r, lookup_value in regexps:
+                if r.search(value):
+                    if not lookup_value:
+                        return result
+                    return self.render(style_attr or lookup_value, result)
+            return result
+        return proc
+
     def by_interval_lookup(self, style_key, style_value):
         """Return a processor for an "interval" style value.
 
@@ -394,6 +424,7 @@ class StyleProcessors(object):
 
         fns = {"simple": self.by_key,
                "lookup": self.by_lookup,
+               "re_lookup": self.by_re_lookup,
                "interval": self.by_interval_lookup}
 
         for key in self.style_types:

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -507,6 +507,48 @@ def test_tabular_write_lookup_non_hashable():
     assert_eq_repr(out.stdout, expected)
 
 
+def test_tabular_write_re_lookup_color():
+    out = Tabular(
+        style={"name": {"width": 3},
+               "status":
+               {"color": {"re_lookup": [["good", "green"],
+                                        ["^bad$", "red"]]},
+                "width": 12}})
+
+    out(OrderedDict([("name", "foo"),
+                     ("status", "good")]))
+    out(OrderedDict([("name", "bar"),
+                     ("status", "really good")]))
+    out(OrderedDict([("name", "oof"),
+                     ("status", "bad")]))
+    out(OrderedDict([("name", "rab"),
+                     ("status", "not bad")]))
+
+    expected = "foo " + capres("green", "good") + "        \n" + \
+               "bar " + capres("green", "really good") + " \n" + \
+               "oof " + capres("red", "bad") + "         \n" + \
+               "rab not bad     \n"
+    assert_eq_repr(out.stdout, expected)
+
+
+def test_tabular_write_re_lookup_bold():
+    out = Tabular(
+        style={"name": {"width": 3},
+               "status":
+               {"bold": {"re_lookup": [["^!![XYZ]$", False],
+                                       ["^!!.$", True]]},
+                "width": 3}})
+
+    out(OrderedDict([("name", "foo"),
+                     ("status", "!!Z")]))
+    out(OrderedDict([("name", "bar"),
+                     ("status", "!!y")]))
+
+    expected = "foo !!Z\n" + \
+               "bar " + capres("bold", "!!y") + "\n"
+    assert_eq_repr(out.stdout, expected)
+
+
 def test_tabular_write_intervals_color():
     out = Tabular(style={"name": {"width": 3},
                          "percent": {"color": {"interval":

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -513,19 +513,20 @@ def test_tabular_write_re_lookup_color():
                "status":
                {"color": {"re_lookup": [["good", "green"],
                                         ["^bad$", "red"]]},
-                "width": 12}})
+                "width": 12},
+               "default_": {"re_flags": ["I"]}})
 
     out(OrderedDict([("name", "foo"),
                      ("status", "good")]))
     out(OrderedDict([("name", "bar"),
-                     ("status", "really good")]))
+                     ("status", "really GOOD")]))
     out(OrderedDict([("name", "oof"),
                      ("status", "bad")]))
     out(OrderedDict([("name", "rab"),
                      ("status", "not bad")]))
 
     expected = "foo " + capres("green", "good") + "        \n" + \
-               "bar " + capres("green", "really good") + " \n" + \
+               "bar " + capres("green", "really GOOD") + " \n" + \
                "oof " + capres("red", "bad") + "         \n" + \
                "rab not bad     \n"
     assert_eq_repr(out.stdout, expected)


### PR DESCRIPTION
Add new style attribute `re_lookup` (and associated `re_flags` attribute).

---

Demo:

```python
#!/usr/bin/python3
from pyout import Tabular

rows = [
    {"name": "foo", "status": "ok"},
    {"name": "bar", "status": "DOOMED"},
    {"name": "baz", "status": "unknown"}
]

style = {"status": {"color":
                    {"re_lookup": [["(good|ok)", "green"],
                                   ["^doomed$", "red"]]},
                    "re_flags": ["I"]}}


with Tabular(["name", "status"], style=style) as out:
    for row in rows:
        out(row)
```
