### PR TITLE
Minimally useful execution on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The new style attribute "re_lookup" adds support for styling a value
   when it matches a regular expression.
 
+- `pyout` should now run, in a very limited way, on Windows.  The
+  `Tabular` class used on Windows, `tabular_dummy.Tabular`, does not
+  support updating previous lines or styling values with the "color",
+  "bold", or "underline" keys.
+
 ## [0.3.0] - 2018-12-18
 
 ### Added

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ lack polish and documentation.
 
 It is developed and tested under Python 2 and 3 in GNU/Linux
 environments and is expected to work in macOS environments as well.
-There is currently no Windows support.
+There is currently very limited Windows support.
 
 
 License

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+# CI on Windows via appveyor
+#
+# Modified from datalad-revolution's configuration file.
+
+build: false
+
+environment:
+  matrix:
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.1"
+      PYTHON_ARCH: "32"
+      MINICONDA: C:\Miniconda35
+
+init:
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"
+
+install:
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  - "conda create -q -n test-environment python=%PYTHON_VERSION%"
+  - activate test-environment
+  - python -c "import sys; print(sys.path)"
+  - pip install codecov
+  - pip install -e ".[full]"
+
+test_script:
+  - coverage run -m pytest --doctest-ignore-import-errors -rs && coverage xml
+
+after_test:
+  - ps: |
+      $env:PATH = 'C:\msys64\usr\bin;' + $env:PATH
+      Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
+      bash codecov.sh -f "coverage.xml"

--- a/pyout/__init__.py
+++ b/pyout/__init__.py
@@ -5,7 +5,15 @@ Exposes a single entry point, the Tabular class.
 
 from __future__ import unicode_literals
 
+import sys
+
 __version__ = "0.1.0"
 
 from pyout.elements import schema
-from pyout.tabular import Tabular
+
+if sys.platform == "win32":
+    from pyout.tabular_dummy import Tabular
+else:
+    from pyout.tabular import Tabular
+
+del sys

--- a/pyout/tabular_dummy.py
+++ b/pyout/tabular_dummy.py
@@ -1,0 +1,64 @@
+"""Not much of an interface for styling tabular terminal output.
+
+This module defines a mostly useless Tabular entry point.  Previous lines are
+not updated, and the results are not styled (e.g., no coloring or bolding of
+values).  In other words, this is not a real attempt to support Windows.
+"""
+
+from __future__ import unicode_literals
+
+import sys
+
+from pyout import interface
+from pyout.common import ContentWithSummary
+from pyout.common import StyleFields
+from pyout.field import StyleProcessors
+
+
+class NoUpdateTerminalStream(interface.Stream):
+
+    supports_updates = False
+
+    def __init__(self, stream=None):
+        self.stream = stream or sys.stdout
+
+    def _die(self, *args, **kwargs):
+        raise NotImplementedError("{!s} does not support 'update' methods"
+                                  .format(self.__class__.__name__))
+
+    clear_last_lines = _die
+    overwrite_line = _die
+    move_to = _die
+
+    # Height and width are the fallback defaults of py3's
+    # shutil.get_terminal_size().
+
+    @property
+    def width(self):
+        return 80
+
+    @property
+    def height(self):
+        return 24
+
+    def write(self, text):
+        self.stream.write(text)
+
+
+class NoopProcessors(StyleProcessors):
+
+    def render(self, _, value):
+        return value
+
+
+class Tabular(interface.Writer):
+    """Like `pyout.tabular.Tabular`, but broken.
+
+    This doesn't support terminal styling or updating previous content.
+    """
+
+    def __init__(self, columns=None, style=None):
+        self._stream = NoUpdateTerminalStream()
+        self._content = ContentWithSummary(
+            StyleFields(style, NoopProcessors()))
+        super(Tabular, self).__init__(columns, style)

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import pytest
+
+blessings = pytest.importorskip("blessings")
+
 from collections import Counter
 from collections import OrderedDict
 from curses import tigetstr
@@ -11,9 +15,7 @@ import sys
 import time
 import traceback
 
-import blessings
 from mock import patch
-import pytest
 from six.moves import StringIO
 
 from pyout import Tabular as TheRealTabular

--- a/pyout/tests/test_tabular_dummy.py
+++ b/pyout/tests/test_tabular_dummy.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from mock import patch
+import pytest
+from six.moves import StringIO
+
+from pyout.tabular_dummy import NoUpdateTerminalStream
+from pyout.tabular_dummy import Tabular
+
+
+def test_stream_update_fail():
+    stream = NoUpdateTerminalStream()
+    with pytest.raises(NotImplementedError):
+        stream.clear_last_lines(3)
+
+
+def test_stream_update_hardcodes_height_width():
+    stream = NoUpdateTerminalStream()
+    assert stream.width == 80
+    assert stream.height == 24
+
+
+def test_tabular_basic():
+    with patch("pyout.interface.sys.stdout.isatty", return_value=True):
+        out = Tabular(["name", "status"],
+                      style={"name": {"color": "green",
+                                      "width": {"marker": "…", "max": 4},
+                                      "transform": lambda x: x.upper()}})
+    out._stream.stream = StringIO()
+    with out:
+        out({"name": "foo", "status": "fine"})
+        out({"name": "barbecue", "status": "dandy"})
+
+    # The default mode for tabular_dummy.Tabular is "incremental".
+    assert out._stream.stream.getvalue() == ("FOO fine\n"
+                                             "FOO  fine \n"
+                                             "BAR… dandy\n")
+
+
+def test_tabular_update_mode_disallowed():
+    out = Tabular(["name", "status"])
+    with pytest.raises(ValueError):
+        out.mode = "update"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 from setuptools import setup
 
 requires = {
-    "core": ["blessings", "six"],
+    "core": ["blessings; sys_platform != 'win32'",
+             "six"],
     "tests": ["pytest", "pytest-timeout", "mock"],
     "validation": ["jsonschema"],
 }


### PR DESCRIPTION
On Windows replace the `Tabular` with one that doesn't support styling or updating previous lines.

Let's see how the AppVeyor run goes.