### PR TITLE
re_lookup: Guard against non-string values

### DIFF
--- a/pyout/field.py
+++ b/pyout/field.py
@@ -344,6 +344,8 @@ class StyleProcessors(object):
                    for r, v in style_value["re_lookup"]]
 
         def proc(value, result):
+            if not isinstance(value, six.string_types):
+                return result
             for r, lookup_value in regexps:
                 if r.search(value):
                     if not lookup_value:

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -960,6 +960,26 @@ def test_tabular_write_callable_transform_nothing():
 
 
 @pytest.mark.timeout(10)
+def test_tabular_write_callable_re_lookup_non_string():
+    delay0 = Delayed(3)
+    delay1 = Delayed("4")
+
+    out = Tabular(["name", "status"],
+                  style={"status": {"color":
+                                    {"re_lookup": [["[0-9]", "green"]]}}})
+    with out:
+        out({"name": "foo", "status": delay0.run})
+        out({"name": "bar", "status": delay1.run})
+        delay0.now = True
+        delay1.now = True
+    lines = out.stdout.splitlines()
+    # 3 was passed in as a number, so re_lookup ignores it
+    assert_contains_nc(lines, "foo 3")
+    # ... but it matches "4".
+    assert_contains_nc(lines, "bar " + capres("green", "4"))
+
+
+@pytest.mark.timeout(10)
 def test_tabular_write_callable_values_multi_return():
     delay = Delayed({"status": "done", "path": "/tmp/a"})
 


### PR DESCRIPTION
The processor doesn't necessarily receive a string value.  Some common
cases are Nothing() objects for asynchronous values and numbers.
Pass the result for non-string values back untouched.

Another option would be to convert it to a string.  That could lead to
unintentional matches on str(object), but at the same time, that _is_
what will be shown, so perhaps it wouldn't be surprising.  For now, go
with the stricter route, adding a test that demonstrates the behavior.
We can revisit it if needed.