### PR TITLE
interface: Provide callers access to row values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   support updating previous lines or styling values with the "color",
   "bold", or "underline" keys.
 
+- The Tabular class now returns a row's value when indexed with a
+  tuple containing the ID values for that row.  This is useful for
+  inspecting values populated by asynchronous functions.
+
 ## [0.3.0] - 2018-12-18
 
 ### Added

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -557,6 +557,10 @@ class Content(object):
 
     __nonzero__ = __bool__  # py2
 
+    def __getitem__(self, key):
+        idx = self._idmap[key]
+        return self._rows[idx].row
+
     @property
     def rows(self):
         """Data and summary rows.

--- a/pyout/interface.py
+++ b/pyout/interface.py
@@ -366,3 +366,27 @@ class Writer(object):
             else:
                 flat.append(column)
         return flat
+
+    def __getitem__(self, key):
+        """Get the (normalized) row for `key`.
+
+        This interface is focused on _writing_ output, and the caller usually
+        knows the values.  However, this method can be useful for retrieving
+        values that were produced asynchronously (see __call__).
+
+        Parameters
+        ----------
+        key : tuple
+            Unique ID for a row, as specified by the `ids` property.
+
+        Returns
+        -------
+        A dictionary with the row's current value.
+        """
+        try:
+            return self._content[key]
+        except KeyError as exc:
+            # Suppress context in py2 compatible way.
+            newexc = KeyError(exc)
+            newexc.__cause__ = None
+            raise newexc

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -1167,6 +1167,19 @@ def test_tabular_write_delayed(form):
     assert eq_repr_noclear(lines[-1], "foo 1 2 3")
 
 
+@pytest.mark.timeout(10)
+def test_tabular_write_inspect_with_getitem():
+    delay0 = Delayed("done")
+    out = Tabular(["name", "status"])
+    with out:
+        out({"name": "foo", "status": ("thinking", delay0.run)})
+        delay0.now = True
+    out[("foo",)] == {"name": "foo", "status": "done"}
+
+    with pytest.raises(KeyError):
+        out[("nothere",)]
+
+
 def test_tabular_summary():
 
     def nbad(xs):


### PR DESCRIPTION
```
Callers usually know the row values because they are passing them in
directly.  However, if values are being populated asynchronously (say
a function that connects to a remote and checks the status), callers
don't have an easy way to access them even though the values may be of
interest.

Give callers access to a row's value via __getitem__().
```