### PR TITLE
Support hiding columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   style attribute takes a "weight" key to allow a column's growth to
   be prioritized.
 
+- The width style attribute learned to take fraction that represents
+  the proportion of the table.  For example, setting the "max" key to
+  0.5 means that the key should exceed half of the total table width.
+
+
 ## [0.4.1] - 2019-10-02
 
 Fix stale `pyout.__version__`, which hasn't been updated since v0.1.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   required.
 
 
+### Changed
+
+- The calculation of auto-width columns has been enhanced so that the
+  available width is more evenly spread across the columns.
+
+
 ## [0.4.1] - 2019-10-02
 
 Fix stale `pyout.__version__`, which hasn't been updated since v0.1.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - The calculation of auto-width columns has been enhanced so that the
-  available width is more evenly spread across the columns.
-
+  available width is more evenly spread across the columns.  The width
+  style attribute takes a "weight" key to allow a column's growth to
+  be prioritized.
 
 ## [0.4.1] - 2019-10-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for Python 2 has been dropped.  Python 3.4 or later is
   required.
 
+### Added
+
+- A new style attribute, "hide", makes it possible to hide a column,
+  either unconditionally or until `Tabular` is called with a record
+  that includes the column.
 
 ### Changed
 

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -270,6 +270,8 @@ class StyleFields(object):
              self.width_separtor])
         lgr.debug("Calculated fixed width as %d", self.width_fixed)
 
+        self._check_widths()
+
     def _compose(self, name, attributes):
         """Construct a style taking `attributes` from the column styles.
 
@@ -348,6 +350,13 @@ class StyleFields(object):
         """Whether the style specifies a header.
         """
         return self.style["header_"] is not None
+
+    def _check_widths(self):
+        columns = self.columns
+        width_table = self.style["width_"]
+        if len(columns) > width_table:
+            raise elements.StyleError(
+                "Number of columns exceeds available table width")
 
     def _set_widths(self, row, proc_group):
         """Update auto-width Fields based on `row`.

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -297,22 +297,33 @@ class StyleFields(object):
 
     def _setup_fields(self):
         fields = {}
+        style = self.style
+        width_table = style["width_"]
+
+        def frac_to_int(x):
+            if x and 0 < x < 1:
+                result = int(x * width_table)
+                lgr.debug("Converted fraction %f to %d", x, result)
+            else:
+                result = x
+            return result
+
         for column in self.columns:
             lgr.debug("Setting up field for column %r", column)
-            cstyle = self.style[column]
+            cstyle = style[column]
             style_width = cstyle["width"]
 
             # Convert atomic values into the equivalent complex form.
             if style_width == "auto":
                 style_width = {}
-            elif isinstance(style_width, int):
+            elif not isinstance(style_width, Mapping):
                 style_width = {"width": style_width}
 
             is_auto = "width" not in style_width
             if is_auto:
                 lgr.debug("Automatically adjusting width for %s", column)
-                width = style_width.get("min", 0)
-                wmax = style_width.get("max")
+                width = frac_to_int(style_width.get("min", 0))
+                wmax = frac_to_int(style_width.get("max"))
                 autoval = {"max": wmax, "min": width,
                            "weight": style_width.get("weight", 1)}
                 self.autowidth_columns[column] = autoval
@@ -322,7 +333,7 @@ class StyleFields(object):
                 if "min" in style_width or "max" in style_width:
                     raise ValueError(
                         "'min' and 'max' are incompatible with 'width'")
-                width = style_width["width"]
+                width = frac_to_int(style_width["width"])
                 lgr.debug("Setting width of column %r to %d",
                           column, width)
 

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -257,18 +257,7 @@ class StyleFields(object):
             "width_", elements.default("width_"))
         elements.validate(self.style)
         self._setup_fields()
-
-        ngaps = len(self.columns) - 1
-        self.width_separtor = len(self.style["separator_"]) * ngaps
-        lgr.debug("Calculated separator width as %d", self.width_separtor)
-
-        autowidth_columns = self.autowidth_columns
-        fields = self.fields
-        self.width_fixed = sum(
-            [sum(fields[c].width for c in self.columns
-                 if c not in autowidth_columns),
-             self.width_separtor])
-        lgr.debug("Calculated fixed width as %d", self.width_fixed)
+        self._set_fixed_widths()
 
         self._check_widths()
 
@@ -379,6 +368,21 @@ class StyleFields(object):
                 "The number of auto-width columns ({}) "
                 "exceeds the available width ({})"
                 .format(len(autowidth_columns), width_auto))
+
+    def _set_fixed_widths(self):
+        """Set fixed-width attributes.
+        """
+        ngaps = len(self.columns) - 1
+        self.width_separtor = len(self.style["separator_"]) * ngaps
+        lgr.debug("Calculated separator width as %d", self.width_separtor)
+
+        autowidth_columns = self.autowidth_columns
+        fields = self.fields
+        self.width_fixed = sum(
+            [sum(fields[c].width for c in self.columns
+                 if c not in autowidth_columns),
+             self.width_separtor])
+        lgr.debug("Calculated fixed width as %d", self.width_fixed)
 
     def _set_widths(self, row, proc_group):
         """Update auto-width Fields based on `row`.

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -359,7 +359,8 @@ class StyleFields(object):
         fields = self.fields
 
         width_separtor = self.width_separtor
-        width_free = self.style["width_"] - sum(
+        width_table = self.style["width_"]
+        width_free = width_table - sum(
             [sum(fields[c].width for c in columns),
              width_separtor])
 
@@ -368,7 +369,7 @@ class StyleFields(object):
                 [sum(fields[c].width for c in columns
                      if c not in autowidth_columns),
                  width_separtor])
-            assert width_fixed > self.style["width_"], "bug in width logic"
+            assert width_fixed > width_table, "bug in width logic"
             raise elements.StyleError(
                 "Fixed widths specified in style exceed total width")
         elif width_free == 0:

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -381,7 +381,7 @@ class StyleFields(object):
 
         lgr.debug("Checking width for row %r", row)
         adjusted = False
-        for column in sorted(self.columns, key=lambda c: fields[c].width):
+        for column in sorted(autowidth_columns, key=lambda c: fields[c].width):
             # ^ Sorting the columns by increasing widths isn't necessary; we do
             # it so that columns that already take up more of the screen don't
             # continue to grow and use up free width before smaller columns
@@ -390,38 +390,37 @@ class StyleFields(object):
                 lgr.debug("Giving up on checking widths; no free width left")
                 break
 
-            if column in autowidth_columns:
-                field = fields[column]
-                lgr.debug("Checking width of column %r "
-                          "(field width: %d, free width: %d)",
-                          column, field.width, width_free)
-                # If we've added any style transform functions as
-                # pre-format processors, we want to measure the width
-                # of their result rather than the raw value.
-                if field.pre[proc_group]:
-                    value = field(row[column], keys=[proc_group],
-                                  exclude_post=True)
-                else:
-                    value = row[column]
-                value = str(value)
-                value_width = len(value)
-                wmax = autowidth_columns[column]["max"]
-                if value_width > field.width:
-                    width_old = field.width
-                    width_available = width_free + field.width
-                    width_new = min(value_width,
-                                    wmax or width_available,
-                                    width_available)
-                    if width_new > width_old:
-                        adjusted = True
-                        field.width = width_new
-                        lgr.debug("Adjusting width of %r column from %d to %d "
-                                  "to accommodate value %r",
-                                  column, width_old, field.width, value)
-                        self._truncaters[column].length = field.width
-                        width_free -= field.width - width_old
-                        lgr.debug("Free width is %d after processing column %r",
-                                  width_free, column)
+            field = fields[column]
+            lgr.debug("Checking width of column %r "
+                      "(field width: %d, free width: %d)",
+                      column, field.width, width_free)
+            # If we've added any style transform functions as pre-format
+            # processors, we want to measure the width of their result rather
+            # than the raw value.
+            if field.pre[proc_group]:
+                value = field(row[column], keys=[proc_group],
+                              exclude_post=True)
+            else:
+                value = row[column]
+            value = str(value)
+            value_width = len(value)
+            wmax = autowidth_columns[column]["max"]
+            if value_width > field.width:
+                width_old = field.width
+                width_available = width_free + field.width
+                width_new = min(value_width,
+                                wmax or width_available,
+                                width_available)
+                if width_new > width_old:
+                    adjusted = True
+                    field.width = width_new
+                    lgr.debug("Adjusting width of %r column from %d to %d "
+                              "to accommodate value %r",
+                              column, width_old, field.width, value)
+                    self._truncaters[column].length = field.width
+                    width_free -= field.width - width_old
+                    lgr.debug("Free width is %d after processing column %r",
+                              width_free, column)
         return adjusted
 
     def _proc_group(self, style, adopt=True):

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -226,6 +226,7 @@ class StyleFields(object):
         self.columns = None
         self.autowidth_columns = {}
 
+        self.width_fixed = None
         self.width_separtor = None
         self.fields = None
         self._truncaters = {}
@@ -260,6 +261,14 @@ class StyleFields(object):
         ngaps = len(self.columns) - 1
         self.width_separtor = len(self.style["separator_"]) * ngaps
         lgr.debug("Calculated separator width as %d", self.width_separtor)
+
+        autowidth_columns = self.autowidth_columns
+        fields = self.fields
+        self.width_fixed = sum(
+            [sum(fields[c].width for c in self.columns
+                 if c not in autowidth_columns),
+             self.width_separtor])
+        lgr.debug("Calculated fixed width as %d", self.width_fixed)
 
     def _compose(self, name, attributes):
         """Construct a style taking `attributes` from the column styles.
@@ -360,15 +369,12 @@ class StyleFields(object):
 
         width_separtor = self.width_separtor
         width_table = self.style["width_"]
+        width_fixed = self.width_fixed
         width_free = width_table - sum(
             [sum(fields[c].width for c in columns),
              width_separtor])
 
         if width_free < 0:
-            width_fixed = sum(
-                [sum(fields[c].width for c in columns
-                     if c not in autowidth_columns),
-                 width_separtor])
             assert width_fixed > width_table, "bug in width logic"
             raise elements.StyleError(
                 "Fixed widths specified in style exceed total width")

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -372,17 +372,20 @@ class StyleFields(object):
     def _set_fixed_widths(self):
         """Set fixed-width attributes.
         """
-        ngaps = len(self.columns) - 1
-        self.width_separtor = len(self.style["separator_"]) * ngaps
-        lgr.debug("Calculated separator width as %d", self.width_separtor)
+        columns = self.columns
+        ngaps = len(columns) - 1
+        width_separtor = len(self.style["separator_"]) * ngaps
+        lgr.debug("Calculated separator width as %d", width_separtor)
 
         autowidth_columns = self.autowidth_columns
         fields = self.fields
-        self.width_fixed = sum(
-            [sum(fields[c].width for c in self.columns
-                 if c not in autowidth_columns),
-             self.width_separtor])
-        lgr.debug("Calculated fixed width as %d", self.width_fixed)
+        width_fixed = sum([sum(fields[c].width for c in columns
+                               if c not in autowidth_columns),
+                           width_separtor])
+        lgr.debug("Calculated fixed width as %d", width_fixed)
+
+        self.width_separtor = width_separtor
+        self.width_fixed = width_fixed
 
     def _set_widths(self, row, proc_group):
         """Update auto-width Fields based on `row`.

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -767,7 +767,9 @@ class ContentWithSummary(Content):
         lgr.log(9, "Updating with .summary set to %s", self.summary)
         content, status = super(ContentWithSummary, self).update(row, style)
         if self.summary:
-            summ_rows = self.summary.summarize([r.row for r in self._rows])
+            summ_rows = self.summary.summarize(
+                self.columns,
+                [r.row for r in self._rows])
 
             def join():
                 return "".join(self._render(summ_rows))

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -231,6 +231,9 @@ class StyleFields(object):
         self.fields = None
         self._truncaters = {}
 
+        self.hidden = {}  # column => {True, "if-empty", False}
+        self._visible_columns = None  # cached list of visible columns
+
     def build(self, columns):
         """Build the style and fields.
 
@@ -257,9 +260,9 @@ class StyleFields(object):
             "width_", elements.default("width_"))
         elements.validate(self.style)
         self._setup_fields()
-        self._set_fixed_widths()
 
-        self._check_widths()
+        self.hidden = {c: self.style[c]["hide"] for c in columns}
+        self._reset_width_info()
 
     def _compose(self, name, attributes):
         """Construct a style taking `attributes` from the column styles.
@@ -352,40 +355,62 @@ class StyleFields(object):
         """
         return self.style["header_"] is not None
 
+    @property
+    def visible_columns(self):
+        """List of columns that are not marked as hidden.
+
+        This value is cached and becomes invalid if column visibility has
+        changed since the last `render` call.
+        """
+        if self._visible_columns is None:
+            hidden = self.hidden
+            self._visible_columns = [c for c in self.columns if not hidden[c]]
+        return self._visible_columns
+
     def _check_widths(self):
-        columns = self.columns
+        visible = self.visible_columns
         autowidth_columns = self.autowidth_columns
         width_table = self.style["width_"]
-        if len(columns) > width_table:
+        if len(visible) > width_table:
             raise elements.StyleError(
-                "Number of columns exceeds available table width")
+                "Number of visible columns exceeds available table width")
 
         width_fixed = self.width_fixed
         width_auto = width_table - width_fixed
 
-        if width_auto < len(autowidth_columns):
+        if width_auto < len(set(autowidth_columns).intersection(visible)):
             raise elements.StyleError(
-                "The number of auto-width columns ({}) "
+                "The number of visible auto-width columns ({}) "
                 "exceeds the available width ({})"
                 .format(len(autowidth_columns), width_auto))
 
     def _set_fixed_widths(self):
         """Set fixed-width attributes.
+
+        Previously calculated values are invalid if the number of visible
+        columns changes.  Call _reset_width_info() in that case.
         """
-        columns = self.columns
-        ngaps = len(columns) - 1
+        visible = self.visible_columns
+        ngaps = len(visible) - 1
         width_separtor = len(self.style["separator_"]) * ngaps
         lgr.debug("Calculated separator width as %d", width_separtor)
 
         autowidth_columns = self.autowidth_columns
         fields = self.fields
-        width_fixed = sum([sum(fields[c].width for c in columns
+        width_fixed = sum([sum(fields[c].width for c in visible
                                if c not in autowidth_columns),
                            width_separtor])
         lgr.debug("Calculated fixed width as %d", width_fixed)
 
         self.width_separtor = width_separtor
         self.width_fixed = width_fixed
+
+    def _reset_width_info(self):
+        """Reset visibility-dependent information.
+        """
+        self._visible_columns = None
+        self._set_fixed_widths()
+        self._check_widths()
 
     def _set_widths(self, row, proc_group):
         """Update auto-width Fields based on `row`.
@@ -413,7 +438,14 @@ class StyleFields(object):
 
         # Check what width each row wants.
         lgr.debug("Checking width for row %r", row)
+        hidden = self.hidden
         for column in autowidth_columns:
+            if hidden[column]:
+                lgr.debug("%r is hidden; setting width to 0",
+                          column)
+                autowidth_columns[column]["wants"] = 0
+                continue
+
             field = fields[column]
             lgr.debug("Checking width of column %r (current field width: %d)",
                       column, field.width)
@@ -555,7 +587,7 @@ class StyleFields(object):
         else:
             return "default"
 
-    def render(self, row, style=None, adopt=True):
+    def render(self, row, style=None, adopt=True, can_unhide=True):
         """Render fields with values from `row`.
 
         Parameters
@@ -569,12 +601,28 @@ class StyleFields(object):
             Merge `self.style` and `style`, using the latter's keys
             when there are conflicts.  If False, treat `style` as a
             standalone style.
+        can_unhide : bool, optional
+            Whether a non-missing value within `row` is able to unhide a column
+            that is marked with "if_missing".
 
         Returns
         -------
         A tuple with the rendered value (str) and a flag that indicates whether
         the field widths required adjustment (bool).
         """
+        hidden = self.hidden
+        any_unhidden = False
+        if can_unhide:
+            for c in row:
+                val = row[c]
+                if hidden[c] == "if_missing" and not isinstance(val, Nothing):
+                    lgr.debug("Unhiding column %r after encountering %r",
+                              c, val)
+                    hidden[c] = False
+                    any_unhidden = True
+        if any_unhidden:
+            self._reset_width_info()
+
         group = self._proc_group(style, adopt=adopt)
         if group == "override":
             # Override the "default" processor key.
@@ -584,7 +632,7 @@ class StyleFields(object):
             proc_keys = None
 
         adjusted = self._set_widths(row, group)
-        cols = self.columns
+        cols = self.visible_columns
         proc_fields = ((self.fields[c], row[c]) for c in cols)
         # Exclude fields that weren't able to claim any width to avoid
         # surrounding empty values with separators.
@@ -748,6 +796,7 @@ class Content(object):
             row = dict(zip(self.columns, self.columns))
         self._header = ContentRow(row,
                                   kwds={"style": self.fields.style["header_"],
+                                        "can_unhide": False,
                                         "adopt": False})
 
 
@@ -768,7 +817,7 @@ class ContentWithSummary(Content):
         content, status = super(ContentWithSummary, self).update(row, style)
         if self.summary:
             summ_rows = self.summary.summarize(
-                self.columns,
+                self.fields.visible_columns,
                 [r.row for r in self._rows])
 
             def join():

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -577,8 +577,12 @@ class StyleFields(object):
             proc_keys = None
 
         adjusted = self._set_widths(row, group)
-        proc_fields = [self.fields[c](row[c], keys=proc_keys)
-                       for c in self.columns]
+        cols = self.columns
+        proc_fields = ((self.fields[c], row[c]) for c in cols)
+        # Exclude fields that weren't able to claim any width to avoid
+        # surrounding empty values with separators.
+        proc_fields = filter(lambda x: x[0].width > 0, proc_fields)
+        proc_fields = (fld(val, keys=proc_keys) for fld, val in proc_fields)
         return self.style["separator_"].join(proc_fields) + "\n", adjusted
 
 

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -375,6 +375,9 @@ class StyleFields(object):
             lgr.debug("Not checking widths; no free width left")
             return False
 
+        if not autowidth_columns:
+            return False
+
         lgr.debug("Checking width for row %r", row)
         adjusted = False
         for column in sorted(self.columns, key=lambda c: fields[c].width):

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -50,7 +50,14 @@ schema = {
             key specifies a fixed width.  The 'marker' key specifies the marker
             used for truncation ('...' by default).  Where the field is
             truncated can be configured with 'truncate': 'right' (default),
-            'left', or 'center'.""",
+            'left', or 'center'.
+
+            The object can also include a 'weight' key.  Conceptually,
+            assigning widths to each column can be (roughly) viewed as each
+            column claiming _one_ character of available width at a time until
+            a column is at its maximum width or there is no available width
+            left.  Setting a column's weight to an integer N makes it claim N
+            characters each iteration.""",
             "oneOf": [{"type": "integer"},
                       {"type": "string",
                        "enum": ["auto"]},
@@ -59,6 +66,7 @@ schema = {
                            "max": {"type": ["integer", "null"]},
                            "min": {"type": ["integer", "null"]},
                            "width": {"type": "integer"},
+                           "weight": {"type": "integer", "minimum": 1},
                            "marker": {"type": ["string", "boolean"]},
                            "truncate": {"type": "string",
                                         "enum": ["left",

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -63,8 +63,8 @@ schema = {
                        "enum": ["auto"]},
                       {"type": "object",
                        "properties": {
-                           "max": {"type": ["integer", "null"]},
-                           "min": {"type": ["integer", "null"]},
+                           "max": {"type": "integer"},
+                           "min": {"type": "integer"},
                            "width": {"type": "integer"},
                            "weight": {"type": "integer", "minimum": 1},
                            "marker": {"type": ["string", "boolean"]},

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -43,10 +43,11 @@ schema = {
             the column width is automatically adjusted to fit the content and
             may be truncated to ensure that the entire row fits within the
             available output width.  An integer value forces all fields in a
-            column to have a width of the specified value. In addition, an
-            object can be specified.  Its 'min' and 'max' keys specify the
-            minimum and maximum widths allowed, whereas the 'width' key
-            specifies a fixed width.  The 'marker' key specifies the marker
+            column to have a width of the specified value.
+
+            In addition, an object can be specified.  Its 'min' and 'max' keys
+            specify the minimum and maximum widths allowed, whereas the 'width'
+            key specifies a fixed width.  The 'marker' key specifies the marker
             used for truncation ('...' by default).  Where the field is
             truncated can be configured with 'truncate': 'right' (default),
             'left', or 'center'.""",

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -30,6 +30,14 @@ schema = {
                       {"$ref": "#/definitions/interval"}],
             "default": "black",
             "scope": "field"},
+        "hide": {
+            "description": """Whether to hide column.  A value of True
+            unconditionally hides the column.  'if_missing' hides the column
+            until the first non-missing value is encountered.""",
+            "oneOf": [{"type": "boolean"},
+                      {"type": "string", "enum": ["if_missing"]}],
+            "default": False,
+            "scope": "column"},
         "underline": {
             "description": "Whether text is underlined",
             "oneOf": [{"type": "boolean"},
@@ -130,6 +138,7 @@ schema = {
                            "bold": {"$ref": "#/definitions/bold"},
                            "color": {"$ref": "#/definitions/color"},
                            "delayed": {"$ref": "#/definitions/delayed"},
+                           "hide": {"$ref": "#/definitions/hide"},
                            "missing": {"$ref": "#/definitions/missing"},
                            "re_flags": {"$ref": "#/definitions/re_flags"},
                            "transform": {"$ref": "#/definitions/transform"},
@@ -186,6 +195,7 @@ schema = {
             "oneOf": [{"$ref": "#/definitions/styles"},
                       {"type": "null"}],
             "default": {"align": "left",
+                        "hide": False,
                         "width": "auto"},
             "scope": "table"},
         "header_": {

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -38,6 +38,9 @@ schema = {
                       {"$ref": "#/definitions/interval"}],
             "default": False,
             "scope": "field"},
+        "width_type": {
+            "description": "Type for numeric values in 'width'",
+            "oneOf": [{"type": "integer"}]},
         "width": {
             "description": """Width of field.  With the default value, 'auto',
             the column width is automatically adjusted to fit the content and
@@ -58,14 +61,14 @@ schema = {
             a column is at its maximum width or there is no available width
             left.  Setting a column's weight to an integer N makes it claim N
             characters each iteration.""",
-            "oneOf": [{"type": "integer"},
+            "oneOf": [{"$ref": "#/definitions/width_type"},
                       {"type": "string",
                        "enum": ["auto"]},
                       {"type": "object",
                        "properties": {
-                           "max": {"type": "integer"},
-                           "min": {"type": "integer"},
-                           "width": {"type": "integer"},
+                           "max": {"$ref": "#/definitions/width_type"},
+                           "min": {"$ref": "#/definitions/width_type"},
+                           "width": {"$ref": "#/definitions/width_type"},
                            "weight": {"type": "integer", "minimum": 1},
                            "marker": {"type": ["string", "boolean"]},
                            "truncate": {"type": "string",

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -40,7 +40,7 @@ schema = {
             "scope": "field"},
         "width_type": {
             "description": "Type for numeric values in 'width'",
-            "oneOf": [{"type": "integer"}]},
+            "oneOf": [{"type": "integer", "minimum": 1}]},
         "width": {
             "description": """Width of field.  With the default value, 'auto',
             the column width is automatically adjusted to fit the content and

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -40,7 +40,10 @@ schema = {
             "scope": "field"},
         "width_type": {
             "description": "Type for numeric values in 'width'",
-            "oneOf": [{"type": "integer", "minimum": 1}]},
+            "oneOf": [{"type": "integer", "minimum": 1},
+                      {"type": "number",
+                       "exclusiveMinimum": 0,
+                       "exclusiveMaximum": 1}]},
         "width": {
             "description": """Width of field.  With the default value, 'auto',
             the column width is automatically adjusted to fit the content and
@@ -50,10 +53,14 @@ schema = {
 
             In addition, an object can be specified.  Its 'min' and 'max' keys
             specify the minimum and maximum widths allowed, whereas the 'width'
-            key specifies a fixed width.  The 'marker' key specifies the marker
-            used for truncation ('...' by default).  Where the field is
-            truncated can be configured with 'truncate': 'right' (default),
-            'left', or 'center'.
+            key specifies a fixed width.  The values can be given as an integer
+            (representing the number of characters) or as a fraction, which
+            indicates the proportion of the total table width (typically the
+            width of your terminal).
+
+            The 'marker' key specifies the marker used for truncation ('...' by
+            default).  Where the field is truncated can be configured with
+            'truncate': 'right' (default), 'left', or 'center'.
 
             The object can also include a 'weight' key.  Conceptually,
             assigning widths to each column can be (roughly) viewed as each

--- a/pyout/summary.py
+++ b/pyout/summary.py
@@ -26,13 +26,15 @@ class Summary(object):
     def __bool__(self):
         return self._enabled
 
-    def summarize(self, rows):
-        """Return summary rows for `rows`.
+    def summarize(self, columns, rows):
+        """Return summary rows.
 
         Parameters
         ----------
+        columns : list of str
+            Summarize values within these columns.
         rows : list of dicts
-            Normalized rows to summarize.
+            Normalized rows that contain keys for `columns`.
 
         Returns
         -------
@@ -40,7 +42,6 @@ class Summary(object):
         the data and the second is a dict of keyword arguments that can be
         passed to StyleFields.render.
         """
-        columns = list(rows[0].keys())
         agg_styles = {c: self.style[c]["aggregate"]
                       for c in columns if "aggregate" in self.style[c]}
 
@@ -50,6 +51,9 @@ class Summary(object):
             colvals = filter(lambda x: not isinstance(x, Nothing),
                              (row[col] for row in rows))
             summaries[col] = agg_fn(list(colvals))
+
+        if not summaries:
+            return []
 
         # The rest is just restructuring the summaries into rows that are
         # compatible with pyout.Content.  Most the complexity below comes from

--- a/pyout/summary.py
+++ b/pyout/summary.py
@@ -78,5 +78,6 @@ class Summary(object):
 
             summary_rows.append((sumrow,
                                  {"style": self.style.get("aggregate_"),
-                                  "adopt": False}))
+                                  "adopt": False,
+                                  "can_unhide": False}))
         return summary_rows

--- a/pyout/tests/test_summary.py
+++ b/pyout/tests/test_summary.py
@@ -7,9 +7,18 @@ def eq(result, expect):
     assert [r[0] for r in result] == expect
 
 
+def test_summary_summarize_no_agg_columns():
+    sm = Summary({"col1": {}})
+    eq(sm.summarize(["col1"],
+                    [{"col1": "a"},
+                     {"col1": "b"}]),
+       [])
+
+
 def test_summary_summarize_atom_return():
     sm = Summary({"col1": {"aggregate": len}})
-    eq(sm.summarize([{"col1": "a"},
+    eq(sm.summarize(["col1"],
+                    [{"col1": "a"},
                      {"col1": "b"}]),
        [{"col1": 2}])
 
@@ -19,7 +28,8 @@ def test_summary_summarize_list_return():
         return list(sorted(set(map(len, xs))))
 
     sm = Summary({"col1": {"aggregate": unique_lens}})
-    eq(sm.summarize([{"col1": "a"},
+    eq(sm.summarize(["col1"],
+                    [{"col1": "a"},
                      {"col1": "bcd"},
                      {"col1": "ef"},
                      {"col1": "g"}]),
@@ -35,7 +45,8 @@ def test_summary_summarize_multicolumn_return():
     sm = Summary({"col1": {"aggregate": unique_values},
                   "col2": {"aggregate": len},
                   "col3": {"aggregate": unique_values}})
-    eq(sm.summarize([{"col1": "a", "col2": "x", "col3": "c"},
+    eq(sm.summarize(["col1", "col2", "col3"],
+                    [{"col1": "a", "col2": "x", "col3": "c"},
                      {"col1": "b", "col2": "y", "col3": "c"},
                      {"col1": "a", "col2": "z", "col3": "c"}]),
        [{"col1": "a", "col2": 3, "col3": "c"},

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -257,10 +257,10 @@ def test_tabular_write_multicolor():
     assert_eq_repr(out.stdout, expected)
 
 
-def test_tabular_write_empty_string_nostyle():
+def test_tabular_write_all_whitespace_nostyle():
     out = Tabular(style={"name": {"color": "green"}})
-    out({"name": ""})
-    assert_eq_repr(out.stdout, "\n")
+    out({"name": "  "})
+    assert_eq_repr(out.stdout, "  \n")
 
 
 def test_tabular_write_style_flanking():

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -54,7 +54,7 @@ def test_tabular_write_empty_string():
 def test_tabular_write_missing_column():
     out = Tabular(columns=["name", "status"])
     out({"name": "solo"})
-    assert_eq_repr(out.stdout, "solo \n")
+    assert_eq_repr(out.stdout, "solo\n")
 
 
 def test_tabular_write_missing_column_missing_text():
@@ -930,7 +930,7 @@ def test_tabular_write_callable_transform_nothing():
         # function above, which is designed to take a number, won't be called
         # with it.
         out({"name": "foo", "status": delay0.run})
-        assert_eq_repr(out.stdout, "foo \n")
+        assert_eq_repr(out.stdout, "foo\n")
         delay0.now = True
     lines = out.stdout.splitlines()
     assert_contains_nc(lines, "foo 5")
@@ -1117,13 +1117,13 @@ def test_tabular_write_delayed(form):
     with out:
         out(row)
     lines = out.stdout.splitlines()
-    assert lines[0] == "foo   "
+    assert lines[0] == "foo"
 
     # Either paired0/paired1 came in first or solo came in first, but
     # paired0/paired1 should arrive together.
     firstin = [ln for ln in lines
-               if eq_repr_noclear(ln, "foo 1 2 ")
-               or eq_repr_noclear(ln, "foo   3")]
+               if eq_repr_noclear(ln, "foo 1 2")
+               or eq_repr_noclear(ln, "foo 3")]
     assert len(firstin) == 1
 
     assert eq_repr_noclear(lines[-1], "foo 1 2 3")

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -798,6 +798,13 @@ def test_tabular_fixed_width_exceeds_total():
         out(OrderedDict([("name", ""), ("status", "")]))
 
 
+def test_tabular_number_of_columns_exceeds_total_width():
+    cols = ["a", "b", "c", "d"]
+    out = Tabular(columns=cols, style={"width_": 3})
+    with pytest.raises(StyleError):
+        out([c + "val" for c in cols])
+
+
 def test_tabular_auto_width_exceeds_total():
     out = Tabular(style={"width_": 13})
     out(OrderedDict([("name", "foobert"),

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -762,6 +762,41 @@ def test_tabular_write_autowidth_min_max_with_header():
     assert_contains_nc(lines1, "bar  BAD!!...")
 
 
+def test_tabular_write_autowidth_min_frac():
+    out = Tabular(style={"width_": 12,
+                         "name": {"width": {"min": 0.5}}})
+    out(OrderedDict([("name", "foo"),
+                     ("status", "unknown")]))
+
+    # 0.5 of table width => 6 characters for "foo"
+    assert out.stdout == "foo    un...\n"
+
+
+def test_tabular_write_autowidth_max_frac():
+    out = Tabular(style={"width_": 12,
+                         "name": {"width": {"max": 0.5}}})
+    out(OrderedDict([("name", "foo"),
+                     ("status", "ok")]))
+
+    # 0.5 of table width => 6 characters for "foo", but it only needs 3.
+    assert out.stdout == "foo ok\n"
+
+    out(OrderedDict([("name", "longerthanmax"),
+                     ("status", "ko")]))
+
+    lines0 = out.stdout.splitlines()
+    # Value over 6 only takes up 6.
+    assert_contains_nc(lines0, "lon... ko")
+
+
+def test_tabular_write_fixed_width_frac():
+    out = Tabular(style={"width_": 20,
+                         "name": {"width": 0.4}})
+    out(OrderedDict([("name", "foo"),
+                     ("status", "ok")]))
+    assert out.stdout == "foo      ok\n"
+
+
 def test_tabular_write_autowidth_different_data_types_same_output():
     out_dict = Tabular(["name", "status"],
                        style={"header_": {},

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -806,11 +806,16 @@ def test_tabular_number_of_columns_exceeds_total_width():
 
 
 def test_tabular_auto_width_exceeds_total():
-    out = Tabular(style={"width_": 13})
-    out(OrderedDict([("name", "foobert"),
-                     ("status", "okiguess"),
-                     ("path", "illbedropped:(")]))
-    assert out.stdout == "foobert o... \n"
+    out = Tabular(style={"width_": 13,
+                         "default_": {"width": {"marker": "…"}}})
+    out(OrderedDict([("name", "abcd"),
+                     ("status", "efghi"),
+                     ("path", "jklm")]))
+    # The values are divided evenly.  Subtracting the separators, there are 11
+    # available spaces.  'status' and 'path' get 4, while 'name' gets the
+    # remaining 3.  'name' is shorted just because the columns are processed in
+    # reverse alphabetical order.
+    assert out.stdout == "ab… efg… jklm\n"
 
 
 def test_tabular_auto_width_exceeds_total_multiline():
@@ -820,12 +825,13 @@ def test_tabular_auto_width_exceeds_total_multiline():
                      ("path", "t/")]))
     assert out.stdout == "abcd efg t/\n"
 
-    # name gets truncated because it claims the most width in the table so far.
-    out(OrderedDict([("name", "notme"),
+    # name gets truncated due to predictable but arbitrary reverse alphabetical
+    # sorting when assigning widths.
+    out(OrderedDict([("name", "mooost"),
                      ("status", "metoo"),
                      ("path", "here")]))
     lines0 = out.stdout.splitlines()
-    assert_contains_nc(lines0, "n... metoo here")
+    assert_contains_nc(lines0, "m... metoo here")
 
     out(OrderedDict([("name", "hi"),
                      ("status", "jk"),

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -976,7 +976,7 @@ def test_tabular_write_callable_values_multi_return():
 
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize("nrows", [20, 21])
-def test_tabular_callback_to_hidden_row(nrows):
+def test_tabular_callback_to_offscreen_row(nrows):
     delay = Delayed("OK")
     out = Tabular(style={"status": {"aggregate": len}})
     with out:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 requires = {
     "core": ["blessings; sys_platform != 'win32'"],
     "tests": ["pytest", "pytest-timeout", "mock"],
-    "validation": ["jsonschema"],
+    "validation": ["jsonschema>=3.0.0"],
 }
 
 requires["full"] = list(requires.values())


### PR DESCRIPTION
pyout requires that all columns are specified before writing begins.
If none are explicitly specified, it infers the list of columns from
the first record received.

For some uses cases, it'd be desirable to expand the list of columns
as new keys are encountered (gh-49).  Unfortunately many parts of
pyout assume that the set of columns is fixed, so adding support for
auto-expanding the column list seems like it will require pretty deep
changes.  The issue is complicated by the fact that the request
involves more than being able to give records with new keys when
calling Tabular: asynchronous callbacks, themselves specified as
values to some column(s), should also be able to create new columns.

One of the motivations for auto-expanding the column list is the
desire to not show columns unless they actually contain information.
Address this by allowing columns to be hidden until they contain
something other than a Nothing() value.  Because it's easy to do and
could end up being useful (at least for debugging), also allow columns
to be unconditionally hidden.

The other motivation for auto-expanding columns is to let the caller
avoid specifying (or perhaps even knowing) the column names up front.
Hiding of course doesn't help with this.

Re: #49, #84