### PR TITLE
auto-widths: Distribute width more evenly across columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   style attribute takes a "weight" key to allow a column's growth to
   be prioritized.
 
+- The width style attribute learned to take fraction that represents
+  the proportion of the table.  For example, setting the "max" key to
+  0.5 means that the key should exceed half of the total table width.
+
+
 ## [0.4.1] - 2019-10-02
 
 Fix stale `pyout.__version__`, which hasn't been updated since v0.1.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   required.
 
 
+### Changed
+
+- The calculation of auto-width columns has been enhanced so that the
+  available width is more evenly spread across the columns.
+
+
 ## [0.4.1] - 2019-10-02
 
 Fix stale `pyout.__version__`, which hasn't been updated since v0.1.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - The calculation of auto-width columns has been enhanced so that the
-  available width is more evenly spread across the columns.
-
+  available width is more evenly spread across the columns.  The width
+  style attribute takes a "weight" key to allow a column's growth to
+  be prioritized.
 
 ## [0.4.1] - 2019-10-02
 

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -270,6 +270,8 @@ class StyleFields(object):
              self.width_separtor])
         lgr.debug("Calculated fixed width as %d", self.width_fixed)
 
+        self._check_widths()
+
     def _compose(self, name, attributes):
         """Construct a style taking `attributes` from the column styles.
 
@@ -348,6 +350,13 @@ class StyleFields(object):
         """Whether the style specifies a header.
         """
         return self.style["header_"] is not None
+
+    def _check_widths(self):
+        columns = self.columns
+        width_table = self.style["width_"]
+        if len(columns) > width_table:
+            raise elements.StyleError(
+                "Number of columns exceeds available table width")
 
     def _set_widths(self, row, proc_group):
         """Update auto-width Fields based on `row`.

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -297,22 +297,33 @@ class StyleFields(object):
 
     def _setup_fields(self):
         fields = {}
+        style = self.style
+        width_table = style["width_"]
+
+        def frac_to_int(x):
+            if x and 0 < x < 1:
+                result = int(x * width_table)
+                lgr.debug("Converted fraction %f to %d", x, result)
+            else:
+                result = x
+            return result
+
         for column in self.columns:
             lgr.debug("Setting up field for column %r", column)
-            cstyle = self.style[column]
+            cstyle = style[column]
             style_width = cstyle["width"]
 
             # Convert atomic values into the equivalent complex form.
             if style_width == "auto":
                 style_width = {}
-            elif isinstance(style_width, int):
+            elif not isinstance(style_width, Mapping):
                 style_width = {"width": style_width}
 
             is_auto = "width" not in style_width
             if is_auto:
                 lgr.debug("Automatically adjusting width for %s", column)
-                width = style_width.get("min", 0)
-                wmax = style_width.get("max")
+                width = frac_to_int(style_width.get("min", 0))
+                wmax = frac_to_int(style_width.get("max"))
                 autoval = {"max": wmax, "min": width,
                            "weight": style_width.get("weight", 1)}
                 self.autowidth_columns[column] = autoval
@@ -322,7 +333,7 @@ class StyleFields(object):
                 if "min" in style_width or "max" in style_width:
                     raise ValueError(
                         "'min' and 'max' are incompatible with 'width'")
-                width = style_width["width"]
+                width = frac_to_int(style_width["width"])
                 lgr.debug("Setting width of column %r to %d",
                           column, width)
 

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -359,7 +359,8 @@ class StyleFields(object):
         fields = self.fields
 
         width_separtor = self.width_separtor
-        width_free = self.style["width_"] - sum(
+        width_table = self.style["width_"]
+        width_free = width_table - sum(
             [sum(fields[c].width for c in columns),
              width_separtor])
 
@@ -368,7 +369,7 @@ class StyleFields(object):
                 [sum(fields[c].width for c in columns
                      if c not in autowidth_columns),
                  width_separtor])
-            assert width_fixed > self.style["width_"], "bug in width logic"
+            assert width_fixed > width_table, "bug in width logic"
             raise elements.StyleError(
                 "Fixed widths specified in style exceed total width")
         elif width_free == 0:

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -381,7 +381,7 @@ class StyleFields(object):
 
         lgr.debug("Checking width for row %r", row)
         adjusted = False
-        for column in sorted(self.columns, key=lambda c: fields[c].width):
+        for column in sorted(autowidth_columns, key=lambda c: fields[c].width):
             # ^ Sorting the columns by increasing widths isn't necessary; we do
             # it so that columns that already take up more of the screen don't
             # continue to grow and use up free width before smaller columns
@@ -390,38 +390,37 @@ class StyleFields(object):
                 lgr.debug("Giving up on checking widths; no free width left")
                 break
 
-            if column in autowidth_columns:
-                field = fields[column]
-                lgr.debug("Checking width of column %r "
-                          "(field width: %d, free width: %d)",
-                          column, field.width, width_free)
-                # If we've added any style transform functions as
-                # pre-format processors, we want to measure the width
-                # of their result rather than the raw value.
-                if field.pre[proc_group]:
-                    value = field(row[column], keys=[proc_group],
-                                  exclude_post=True)
-                else:
-                    value = row[column]
-                value = str(value)
-                value_width = len(value)
-                wmax = autowidth_columns[column]["max"]
-                if value_width > field.width:
-                    width_old = field.width
-                    width_available = width_free + field.width
-                    width_new = min(value_width,
-                                    wmax or width_available,
-                                    width_available)
-                    if width_new > width_old:
-                        adjusted = True
-                        field.width = width_new
-                        lgr.debug("Adjusting width of %r column from %d to %d "
-                                  "to accommodate value %r",
-                                  column, width_old, field.width, value)
-                        self._truncaters[column].length = field.width
-                        width_free -= field.width - width_old
-                        lgr.debug("Free width is %d after processing column %r",
-                                  width_free, column)
+            field = fields[column]
+            lgr.debug("Checking width of column %r "
+                      "(field width: %d, free width: %d)",
+                      column, field.width, width_free)
+            # If we've added any style transform functions as pre-format
+            # processors, we want to measure the width of their result rather
+            # than the raw value.
+            if field.pre[proc_group]:
+                value = field(row[column], keys=[proc_group],
+                              exclude_post=True)
+            else:
+                value = row[column]
+            value = str(value)
+            value_width = len(value)
+            wmax = autowidth_columns[column]["max"]
+            if value_width > field.width:
+                width_old = field.width
+                width_available = width_free + field.width
+                width_new = min(value_width,
+                                wmax or width_available,
+                                width_available)
+                if width_new > width_old:
+                    adjusted = True
+                    field.width = width_new
+                    lgr.debug("Adjusting width of %r column from %d to %d "
+                              "to accommodate value %r",
+                              column, width_old, field.width, value)
+                    self._truncaters[column].length = field.width
+                    width_free -= field.width - width_old
+                    lgr.debug("Free width is %d after processing column %r",
+                              width_free, column)
         return adjusted
 
     def _proc_group(self, style, adopt=True):

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -226,6 +226,7 @@ class StyleFields(object):
         self.columns = None
         self.autowidth_columns = {}
 
+        self.width_fixed = None
         self.width_separtor = None
         self.fields = None
         self._truncaters = {}
@@ -260,6 +261,14 @@ class StyleFields(object):
         ngaps = len(self.columns) - 1
         self.width_separtor = len(self.style["separator_"]) * ngaps
         lgr.debug("Calculated separator width as %d", self.width_separtor)
+
+        autowidth_columns = self.autowidth_columns
+        fields = self.fields
+        self.width_fixed = sum(
+            [sum(fields[c].width for c in self.columns
+                 if c not in autowidth_columns),
+             self.width_separtor])
+        lgr.debug("Calculated fixed width as %d", self.width_fixed)
 
     def _compose(self, name, attributes):
         """Construct a style taking `attributes` from the column styles.
@@ -360,15 +369,12 @@ class StyleFields(object):
 
         width_separtor = self.width_separtor
         width_table = self.style["width_"]
+        width_fixed = self.width_fixed
         width_free = width_table - sum(
             [sum(fields[c].width for c in columns),
              width_separtor])
 
         if width_free < 0:
-            width_fixed = sum(
-                [sum(fields[c].width for c in columns
-                     if c not in autowidth_columns),
-                 width_separtor])
             assert width_fixed > width_table, "bug in width logic"
             raise elements.StyleError(
                 "Fixed widths specified in style exceed total width")

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -375,6 +375,9 @@ class StyleFields(object):
             lgr.debug("Not checking widths; no free width left")
             return False
 
+        if not autowidth_columns:
+            return False
+
         lgr.debug("Checking width for row %r", row)
         adjusted = False
         for column in sorted(self.columns, key=lambda c: fields[c].width):

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -50,7 +50,14 @@ schema = {
             key specifies a fixed width.  The 'marker' key specifies the marker
             used for truncation ('...' by default).  Where the field is
             truncated can be configured with 'truncate': 'right' (default),
-            'left', or 'center'.""",
+            'left', or 'center'.
+
+            The object can also include a 'weight' key.  Conceptually,
+            assigning widths to each column can be (roughly) viewed as each
+            column claiming _one_ character of available width at a time until
+            a column is at its maximum width or there is no available width
+            left.  Setting a column's weight to an integer N makes it claim N
+            characters each iteration.""",
             "oneOf": [{"type": "integer"},
                       {"type": "string",
                        "enum": ["auto"]},
@@ -59,6 +66,7 @@ schema = {
                            "max": {"type": ["integer", "null"]},
                            "min": {"type": ["integer", "null"]},
                            "width": {"type": "integer"},
+                           "weight": {"type": "integer", "minimum": 1},
                            "marker": {"type": ["string", "boolean"]},
                            "truncate": {"type": "string",
                                         "enum": ["left",

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -63,8 +63,8 @@ schema = {
                        "enum": ["auto"]},
                       {"type": "object",
                        "properties": {
-                           "max": {"type": ["integer", "null"]},
-                           "min": {"type": ["integer", "null"]},
+                           "max": {"type": "integer"},
+                           "min": {"type": "integer"},
                            "width": {"type": "integer"},
                            "weight": {"type": "integer", "minimum": 1},
                            "marker": {"type": ["string", "boolean"]},

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -43,10 +43,11 @@ schema = {
             the column width is automatically adjusted to fit the content and
             may be truncated to ensure that the entire row fits within the
             available output width.  An integer value forces all fields in a
-            column to have a width of the specified value. In addition, an
-            object can be specified.  Its 'min' and 'max' keys specify the
-            minimum and maximum widths allowed, whereas the 'width' key
-            specifies a fixed width.  The 'marker' key specifies the marker
+            column to have a width of the specified value.
+
+            In addition, an object can be specified.  Its 'min' and 'max' keys
+            specify the minimum and maximum widths allowed, whereas the 'width'
+            key specifies a fixed width.  The 'marker' key specifies the marker
             used for truncation ('...' by default).  Where the field is
             truncated can be configured with 'truncate': 'right' (default),
             'left', or 'center'.""",

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -38,6 +38,9 @@ schema = {
                       {"$ref": "#/definitions/interval"}],
             "default": False,
             "scope": "field"},
+        "width_type": {
+            "description": "Type for numeric values in 'width'",
+            "oneOf": [{"type": "integer"}]},
         "width": {
             "description": """Width of field.  With the default value, 'auto',
             the column width is automatically adjusted to fit the content and
@@ -58,14 +61,14 @@ schema = {
             a column is at its maximum width or there is no available width
             left.  Setting a column's weight to an integer N makes it claim N
             characters each iteration.""",
-            "oneOf": [{"type": "integer"},
+            "oneOf": [{"$ref": "#/definitions/width_type"},
                       {"type": "string",
                        "enum": ["auto"]},
                       {"type": "object",
                        "properties": {
-                           "max": {"type": "integer"},
-                           "min": {"type": "integer"},
-                           "width": {"type": "integer"},
+                           "max": {"$ref": "#/definitions/width_type"},
+                           "min": {"$ref": "#/definitions/width_type"},
+                           "width": {"$ref": "#/definitions/width_type"},
                            "weight": {"type": "integer", "minimum": 1},
                            "marker": {"type": ["string", "boolean"]},
                            "truncate": {"type": "string",

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -40,7 +40,7 @@ schema = {
             "scope": "field"},
         "width_type": {
             "description": "Type for numeric values in 'width'",
-            "oneOf": [{"type": "integer"}]},
+            "oneOf": [{"type": "integer", "minimum": 1}]},
         "width": {
             "description": """Width of field.  With the default value, 'auto',
             the column width is automatically adjusted to fit the content and

--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -40,7 +40,10 @@ schema = {
             "scope": "field"},
         "width_type": {
             "description": "Type for numeric values in 'width'",
-            "oneOf": [{"type": "integer", "minimum": 1}]},
+            "oneOf": [{"type": "integer", "minimum": 1},
+                      {"type": "number",
+                       "exclusiveMinimum": 0,
+                       "exclusiveMaximum": 1}]},
         "width": {
             "description": """Width of field.  With the default value, 'auto',
             the column width is automatically adjusted to fit the content and
@@ -50,10 +53,14 @@ schema = {
 
             In addition, an object can be specified.  Its 'min' and 'max' keys
             specify the minimum and maximum widths allowed, whereas the 'width'
-            key specifies a fixed width.  The 'marker' key specifies the marker
-            used for truncation ('...' by default).  Where the field is
-            truncated can be configured with 'truncate': 'right' (default),
-            'left', or 'center'.
+            key specifies a fixed width.  The values can be given as an integer
+            (representing the number of characters) or as a fraction, which
+            indicates the proportion of the total table width (typically the
+            width of your terminal).
+
+            The 'marker' key specifies the marker used for truncation ('...' by
+            default).  Where the field is truncated can be configured with
+            'truncate': 'right' (default), 'left', or 'center'.
 
             The object can also include a 'weight' key.  Conceptually,
             assigning widths to each column can be (roughly) viewed as each

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -798,6 +798,13 @@ def test_tabular_fixed_width_exceeds_total():
         out(OrderedDict([("name", ""), ("status", "")]))
 
 
+def test_tabular_number_of_columns_exceeds_total_width():
+    cols = ["a", "b", "c", "d"]
+    out = Tabular(columns=cols, style={"width_": 3})
+    with pytest.raises(StyleError):
+        out([c + "val" for c in cols])
+
+
 def test_tabular_auto_width_exceeds_total():
     out = Tabular(style={"width_": 13})
     out(OrderedDict([("name", "foobert"),

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -762,6 +762,41 @@ def test_tabular_write_autowidth_min_max_with_header():
     assert_contains_nc(lines1, "bar  BAD!!...")
 
 
+def test_tabular_write_autowidth_min_frac():
+    out = Tabular(style={"width_": 12,
+                         "name": {"width": {"min": 0.5}}})
+    out(OrderedDict([("name", "foo"),
+                     ("status", "unknown")]))
+
+    # 0.5 of table width => 6 characters for "foo"
+    assert out.stdout == "foo    un...\n"
+
+
+def test_tabular_write_autowidth_max_frac():
+    out = Tabular(style={"width_": 12,
+                         "name": {"width": {"max": 0.5}}})
+    out(OrderedDict([("name", "foo"),
+                     ("status", "ok")]))
+
+    # 0.5 of table width => 6 characters for "foo", but it only needs 3.
+    assert out.stdout == "foo ok\n"
+
+    out(OrderedDict([("name", "longerthanmax"),
+                     ("status", "ko")]))
+
+    lines0 = out.stdout.splitlines()
+    # Value over 6 only takes up 6.
+    assert_contains_nc(lines0, "lon... ko")
+
+
+def test_tabular_write_fixed_width_frac():
+    out = Tabular(style={"width_": 20,
+                         "name": {"width": 0.4}})
+    out(OrderedDict([("name", "foo"),
+                     ("status", "ok")]))
+    assert out.stdout == "foo      ok\n"
+
+
 def test_tabular_write_autowidth_different_data_types_same_output():
     out_dict = Tabular(["name", "status"],
                        style={"header_": {},

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -806,11 +806,16 @@ def test_tabular_number_of_columns_exceeds_total_width():
 
 
 def test_tabular_auto_width_exceeds_total():
-    out = Tabular(style={"width_": 13})
-    out(OrderedDict([("name", "foobert"),
-                     ("status", "okiguess"),
-                     ("path", "illbedropped:(")]))
-    assert out.stdout == "foobert o... \n"
+    out = Tabular(style={"width_": 13,
+                         "default_": {"width": {"marker": "…"}}})
+    out(OrderedDict([("name", "abcd"),
+                     ("status", "efghi"),
+                     ("path", "jklm")]))
+    # The values are divided evenly.  Subtracting the separators, there are 11
+    # available spaces.  'status' and 'path' get 4, while 'name' gets the
+    # remaining 3.  'name' is shorted just because the columns are processed in
+    # reverse alphabetical order.
+    assert out.stdout == "ab… efg… jklm\n"
 
 
 def test_tabular_auto_width_exceeds_total_multiline():
@@ -820,12 +825,13 @@ def test_tabular_auto_width_exceeds_total_multiline():
                      ("path", "t/")]))
     assert out.stdout == "abcd efg t/\n"
 
-    # name gets truncated because it claims the most width in the table so far.
-    out(OrderedDict([("name", "notme"),
+    # name gets truncated due to predictable but arbitrary reverse alphabetical
+    # sorting when assigning widths.
+    out(OrderedDict([("name", "mooost"),
                      ("status", "metoo"),
                      ("path", "here")]))
     lines0 = out.stdout.splitlines()
-    assert_contains_nc(lines0, "n... metoo here")
+    assert_contains_nc(lines0, "m... metoo here")
 
     out(OrderedDict([("name", "hi"),
                      ("status", "jk"),

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 requires = {
     "core": ["blessings; sys_platform != 'win32'"],
     "tests": ["pytest", "pytest-timeout", "mock"],
-    "validation": ["jsonschema"],
+    "validation": ["jsonschema>=3.0.0"],
 }
 
 requires["full"] = list(requires.values())


### PR DESCRIPTION
This draft reworks how we assign widths to the auto-width columns.  It tries to address the [issues mentioned][0] at the "hide columns" pull request (gh-86).  This series will have a lot of interaction with gh-86, and I still need to check how well that one plays on top of this one.

This also adds support for specifying width values as a fraction of the overall table width (gh-85).

[0]: https://github.com/pyout/pyout/pull/86#issuecomment-542427707