### PR TITLE
Extend test of StyleFunctionError's embedded traceback to Python 3

### DIFF
--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -646,9 +646,8 @@ def test_tabular_write_transform_func_error():
         exc_type, value, tb = sys.exc_info()
         try:
             assert isinstance(value, StyleFunctionError)
-            tblines = "\n".join(
-                traceback.format_exception(exc_type, value, tb))
-            assert "in dontlikeints" in tblines
+            names = [x[2] for x in traceback.extract_tb(tb)]
+            assert "dontlikeints" in names
         finally:
             del tb
 


### PR DESCRIPTION
```
As of ea4156ee (BF: Raise StyleFunctionError with original traceback,
2018-02-11), when a transform function raises an exception, we embed
the original traceback so that we don't assume the caller handled the
exception in a way that preserves the original traceback.  The
motivating example for this was DataLad's exc_str() helper, which uses
extract_tb() underneath [*].

The regression test added in ea4156ee uses format_exception(), but
that only catches the issue under Python 2; under Python 3 the
original exception is included in the output.

Switch to using extract_tb() so that this regression test is effective
under Python 3 (which is important because we are about to drop Python
2 support).

[*] ... though, in light of Python 3's explicit chaining, exc_str() is
    arguably flawed.
```