### PR TITLE
Rework asynchronous execution to use concurrent.futures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   controls the maximum number of asynchronous workers that run
   concurrently.
 
+- The `Tabular` class gained a `continue_on_failure` argument.  When
+  set to false, an exception in an asynchronous worker is raised as it
+  is encountered rather than after all asynchronous workers have
+  returned.
+
 ### Changed
 
 - The `mode` property of the `Tabular` class has been removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- The `mode` property of the `Tabular` class has been removed.
+  The mode should instead be specified via the `mode` keyword argument
+  when initializing the class.
+
 - The calculation of auto-width columns has been enhanced so that the
   available width is more evenly spread across the columns.  The width
   style attribute takes a "weight" key to allow a column's growth to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   is encountered rather than after all asynchronous workers have
   returned.
 
+- `Tabular` now waits until the asynchronous workers of the top three
+  rows have completed before adding a new row that would advance the
+  screen.  The number of top rows that are considered can be
+  configured via the new `wait_for_top` keyword argument.
+
 ### Changed
 
 - The `mode` property of the `Tabular` class has been removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   either unconditionally or until `Tabular` is called with a record
   that includes the column.
 
+- The `Tabular` class now accepts a `max_workers` argument that
+  controls the maximum number of asynchronous workers that run
+  concurrently.
+
 ### Changed
 
 - The `mode` property of the `Tabular` class has been removed.

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -764,7 +764,9 @@ class Content(object):
             return str(self), "append"
 
         try:
-            prev_idx = self._idmap[idkey] if idkey in self._idmap else None
+            prev_idx = self._idmap[idkey]
+        except KeyError:
+            prev_idx = None
         except TypeError:
             raise ContentError("ID columns must be hashable")
 

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -674,6 +674,7 @@ class Content(object):
         self._header = None
         self._rows = []
         self._idkey_to_idx = {}
+        self._idx_to_idkey = {}
 
     def init_columns(self, columns, ids):
         """Set up the fields for `columns`.
@@ -761,6 +762,7 @@ class Content(object):
             self._add_header()
             self._rows.append(ContentRow(row, kwds={"style": style}))
             self._idkey_to_idx[idkey] = 0
+            self._idx_to_idkey[0] = idkey
             return str(self), "append"
 
         try:
@@ -780,7 +782,9 @@ class Content(object):
             row = self._rows[prev_idx][0]
         else:
             lgr.debug("Adding row %r to content for first time", idkey)
-            self._idkey_to_idx[idkey] = len(self._rows)
+            nrows = len(self._rows)
+            self._idkey_to_idx[idkey] = nrows
+            self._idx_to_idkey[nrows] = idkey
             self._rows.append(ContentRow(row, kwds={"style": style}))
 
         line, adjusted = self.fields.render(row, style)

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -673,7 +673,7 @@ class Content(object):
 
         self._header = None
         self._rows = []
-        self._idmap = {}
+        self._idkey_to_idx = {}
 
     def init_columns(self, columns, ids):
         """Set up the fields for `columns`.
@@ -697,7 +697,7 @@ class Content(object):
         return bool(self._rows)
 
     def __getitem__(self, key):
-        idx = self._idmap[key]
+        idx = self._idkey_to_idx[key]
         return self._rows[idx].row
 
     @property
@@ -760,11 +760,11 @@ class Content(object):
             lgr.debug("Registering header")
             self._add_header()
             self._rows.append(ContentRow(row, kwds={"style": style}))
-            self._idmap[idkey] = 0
+            self._idkey_to_idx[idkey] = 0
             return str(self), "append"
 
         try:
-            prev_idx = self._idmap[idkey]
+            prev_idx = self._idkey_to_idx[idkey]
         except KeyError:
             prev_idx = None
         except TypeError:
@@ -780,7 +780,7 @@ class Content(object):
             row = self._rows[prev_idx][0]
         else:
             lgr.debug("Adding row %r to content for first time", idkey)
-            self._idmap[idkey] = len(self._rows)
+            self._idkey_to_idx[idkey] = len(self._rows)
             self._rows.append(ContentRow(row, kwds={"style": style}))
 
         line, adjusted = self.fields.render(row, style)

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -727,6 +727,34 @@ class Content(object):
         except RedoContent:
             return "".join(self._render(self.rows))
 
+    def get_idkey(self, idx):
+        """Return ID keys for a row.
+
+        Parameters
+        ----------
+        idx : int
+            Index of row (determined by order it came in to `update`).
+
+        Returns
+        -------
+        ID key (tuple) matching row.  If there is a header, None is return as
+        its ID key.
+
+        Raises
+        ------
+        IndexError if `idx` does not match known row.
+        """
+        if self._header:
+            idx -= 1
+            if idx == -1:
+                return None
+        try:
+            return self._idx_to_idkey[idx]
+        except KeyError:
+            msg = ("Index {!r} outside of current range: [0, {})"
+                   .format(idx, len(self._idkey_to_idx)))
+            raise IndexError(msg) from None
+
     def update(self, row, style):
         """Modify the content.
 

--- a/pyout/interface.py
+++ b/pyout/interface.py
@@ -195,7 +195,14 @@ class Writer(object):
         if exc_value is not None:
             self._abort(msg="\n{!r} raised\n".format(exc_value))
         else:
-            failed = self.wait()
+            try:
+                failed = self.wait()
+            except KeyboardInterrupt:
+                lgr.debug("Caught KeyboardInterrupt "
+                          "while waiting for asynchronous workers")
+                self._abort(msg="\nKeyboard interrupt registered\n")
+                # Raise so that caller can decide how to handle.
+                raise
 
         if self._mode == "final":
             self._stream.write(str(self._content))

--- a/pyout/interface.py
+++ b/pyout/interface.py
@@ -190,8 +190,13 @@ class Writer(object):
     def __enter__(self):
         return self
 
-    def __exit__(self, *args):
-        failed = self.wait()
+    def __exit__(self, _exc_type, exc_value, _tb):
+        failed = None
+        if exc_value is not None:
+            self._abort(msg="\n{!r} raised\n".format(exc_value))
+        else:
+            failed = self.wait()
+
         if self._mode == "final":
             self._stream.write(str(self._content))
         if self._mode != "update" and self._last_summary is not None:

--- a/pyout/interface.py
+++ b/pyout/interface.py
@@ -131,16 +131,6 @@ class Writer(object):
         self._normalizer = RowNormalizer(self._columns,
                                          self._content.fields.style)
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        self.wait()
-        if self._mode == "final":
-            self._stream.write(str(self._content))
-        if self._mode != "update" and self._last_summary is not None:
-            self._stream.write(str(self._last_summary))
-
     def _init_mode(self, streamer):
         value = self._mode
         lgr.debug("Initializing mode with given value of %s", value)
@@ -169,6 +159,16 @@ class Writer(object):
             else:
                 raise ValueError("Stream {} does not support updates"
                                  .format(self._stream))
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.wait()
+        if self._mode == "final":
+            self._stream.write(str(self._content))
+        if self._mode != "update" and self._last_summary is not None:
+            self._stream.write(str(self._last_summary))
 
     @property
     def ids(self):

--- a/pyout/interface.py
+++ b/pyout/interface.py
@@ -336,16 +336,18 @@ class Writer(object):
         with self._write_lock():
             self._write_fn(row, style)
 
+    def _get_last_summary_length(self):
+        last_summary = self._last_summary
+        return len(last_summary.splitlines()) if last_summary else 0
+
     def _write_update(self, row, style=None):
-        if self._last_summary:
-            last_summary_len = len(self._last_summary.splitlines())
+        last_summary_len = self._get_last_summary_length()
+        if last_summary_len > 0:
             # Clear the summary because 1) it has very likely changed, 2)
             # it makes the counting for row updates simpler, 3) and it is
             # possible for the summary lines to shrink.
             lgr.debug("Clearing summary of %d line(s)", last_summary_len)
             self._stream.clear_last_lines(last_summary_len)
-        else:
-            last_summary_len = 0
 
         content, status, summary = self._content.update(row, style)
 

--- a/pyout/interface.py
+++ b/pyout/interface.py
@@ -84,7 +84,8 @@ class Writer(object):
      call Writer.__init__ and then the _init method.
     """
     def __init__(self, columns=None, style=None, stream=None,
-                 interactive=None, mode=None):
+                 interactive=None, mode=None,
+                 max_workers=None):
         self._columns = columns
         self._ids = None
 
@@ -93,6 +94,7 @@ class Writer(object):
         self._normalizer = None
 
         self._pool = None
+        self._max_workers = max_workers
         self._lock = None
 
         self._mode = mode
@@ -304,8 +306,9 @@ class Writer(object):
             tab._write(result)
 
         if self._pool is None:
-            lgr.debug("Initializing pool")
-            self._pool = Pool()
+            lgr.debug("Initializing pool with max workers=%s",
+                      self._max_workers)
+            self._pool = Pool(processes=self._max_workers)
         if self._lock is None:
             lgr.debug("Initializing lock")
             self._lock = multiprocessing.Lock()

--- a/pyout/interface.py
+++ b/pyout/interface.py
@@ -8,9 +8,9 @@ from contextlib import contextmanager
 from functools import partial
 import inspect
 from logging import getLogger
-import multiprocessing
 from multiprocessing.dummy import Pool
 import sys
+import threading
 
 from pyout.common import ContentWithSummary
 from pyout.common import RowNormalizer
@@ -311,7 +311,7 @@ class Writer(object):
             self._pool = Pool(processes=self._max_workers)
         if self._lock is None:
             lgr.debug("Initializing lock")
-            self._lock = multiprocessing.Lock()
+            self._lock = threading.Lock()
 
         for cols, fn in callables:
             cb_func = partial(callback, self, cols)

--- a/pyout/interface.py
+++ b/pyout/interface.py
@@ -396,9 +396,11 @@ class Writer(object):
             result = dict(zip(cols, result))
         elif len(cols) == 1:
             lgr.debug("Processing result as atom")
-            # Don't bother raising an exception if cols != 1
-            # because it would be lost in the thread.
             result = {cols[0]: result}
+        else:
+            raise ValueError(
+                "Expected tuple or mapping for columns {!r}, got {!r}"
+                .format(cols, result))
         result.update(id_vals)
         self._write(result)
 

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -108,6 +108,10 @@ class Tabular(interface.Writer):
 
         Defaults to "update" if the stream supports updates and "incremental"
         otherwise.  If the stream is non-interactive, defaults to "final".
+    max_workers : int, optional
+        Use at most this number of concurrent workers when retrieving values
+        asynchronously (i.e., when producers are specified as row values).  The
+        default is left to `multiprocessing.pool.ThreadPool`.
 
     Examples
     --------
@@ -132,9 +136,11 @@ class Tabular(interface.Writer):
     """
 
     def __init__(self, columns=None, style=None, stream=None,
-                 interactive=None, mode=None):
-        super(Tabular, self).__init__(columns, style, stream=stream,
-                                      interactive=interactive, mode=mode)
+                 interactive=None, mode=None, max_workers=None):
+        super(Tabular, self).__init__(
+            columns, style, stream=stream,
+            interactive=interactive, mode=mode,
+            max_workers=max_workers)
         streamer = TerminalStream(stream=stream, interactive=interactive)
         if streamer.interactive:
             processors = TermProcessors(streamer.term)

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -112,6 +112,10 @@ class Tabular(interface.Writer):
         If an asynchronous worker fails, the default behavior is to continue
         and report the failures at the end.  Set this flag to false in order
         to abort writing the table and raise if any exception is received.
+    wait_for_top : int, optional
+        Wait for the asynchronous workers of this many top-most rows to finish
+        before proceeding with a row before adding a row that would take the
+        top row off screen.
     max_workers : int, optional
         Use at most this number of concurrent workers when retrieving values
         asynchronously (i.e., when producers are specified as row values).  The
@@ -142,12 +146,12 @@ class Tabular(interface.Writer):
 
     def __init__(self, columns=None, style=None, stream=None,
                  interactive=None, mode=None, continue_on_failure=True,
-                 max_workers=None):
+                 wait_for_top=3, max_workers=None):
         super(Tabular, self).__init__(
             columns, style, stream=stream,
             interactive=interactive, mode=mode,
             continue_on_failure=continue_on_failure,
-            max_workers=max_workers)
+            wait_for_top=wait_for_top, max_workers=max_workers)
         streamer = TerminalStream(stream=stream, interactive=interactive)
         if streamer.interactive:
             processors = TermProcessors(streamer.term)

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -111,7 +111,8 @@ class Tabular(interface.Writer):
     max_workers : int, optional
         Use at most this number of concurrent workers when retrieving values
         asynchronously (i.e., when producers are specified as row values).  The
-        default is left to `multiprocessing.pool.ThreadPool`.
+        default matches the default of `concurrent.futures.ThreadPoolExecutor`
+        as of Python 3.8: `min(32, os.cpu_count() + 4)`.
 
     Examples
     --------

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -108,6 +108,10 @@ class Tabular(interface.Writer):
 
         Defaults to "update" if the stream supports updates and "incremental"
         otherwise.  If the stream is non-interactive, defaults to "final".
+    continue_on_failure : bool, optional
+        If an asynchronous worker fails, the default behavior is to continue
+        and report the failures at the end.  Set this flag to false in order
+        to abort writing the table and raise if any exception is received.
     max_workers : int, optional
         Use at most this number of concurrent workers when retrieving values
         asynchronously (i.e., when producers are specified as row values).  The
@@ -137,10 +141,12 @@ class Tabular(interface.Writer):
     """
 
     def __init__(self, columns=None, style=None, stream=None,
-                 interactive=None, mode=None, max_workers=None):
+                 interactive=None, mode=None, continue_on_failure=True,
+                 max_workers=None):
         super(Tabular, self).__init__(
             columns, style, stream=stream,
             interactive=interactive, mode=mode,
+            continue_on_failure=continue_on_failure,
             max_workers=max_workers)
         streamer = TerminalStream(stream=stream, interactive=interactive)
         if streamer.interactive:

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -99,6 +99,15 @@ class Tabular(interface.Writer):
         determined by calling `stream.isatty()`.  If non-interactive, the bold,
         color, and underline keys will be ignored, and the mode will default to
         "final".
+    mode : {update, incremental, final}, optional
+        Mode of display.
+        * update (default): Go back and update the fields.  This includes
+          resizing the automated widths.
+        * incremental: Don't go back to update anything.
+        * final: finalized representation appropriate for redirecting to file
+
+        Defaults to "update" if the stream supports updates and "incremental"
+        otherwise.  If the stream is non-interactive, defaults to "final".
 
     Examples
     --------
@@ -123,9 +132,9 @@ class Tabular(interface.Writer):
     """
 
     def __init__(self, columns=None, style=None, stream=None,
-                 interactive=None):
+                 interactive=None, mode=None):
         super(Tabular, self).__init__(columns, style, stream=stream,
-                                      interactive=interactive)
+                                      interactive=interactive, mode=mode)
         streamer = TerminalStream(stream=stream, interactive=interactive)
         if streamer.interactive:
             processors = TermProcessors(streamer.term)

--- a/pyout/tabular_dummy.py
+++ b/pyout/tabular_dummy.py
@@ -45,9 +45,11 @@ class Tabular(interface.Writer):
     """
 
     def __init__(self, columns=None, style=None, stream=None,
-                 interactive=None, mode=None):
-        super(Tabular, self).__init__(columns, style, stream=stream,
-                                      interactive=interactive, mode=mode)
+                 interactive=None, mode=None, max_workers=None):
+        super(Tabular, self).__init__(
+            columns, style, stream=stream,
+            interactive=interactive, mode=mode,
+            max_workers=max_workers)
         streamer = NoUpdateTerminalStream(
             stream=stream, interactive=interactive)
         super(Tabular, self)._init(style, streamer)

--- a/pyout/tabular_dummy.py
+++ b/pyout/tabular_dummy.py
@@ -45,9 +45,9 @@ class Tabular(interface.Writer):
     """
 
     def __init__(self, columns=None, style=None, stream=None,
-                 interactive=None):
+                 interactive=None, mode=None):
         super(Tabular, self).__init__(columns, style, stream=stream,
-                                      interactive=interactive)
+                                      interactive=interactive, mode=mode)
         streamer = NoUpdateTerminalStream(
             stream=stream, interactive=interactive)
         super(Tabular, self)._init(style, streamer)

--- a/pyout/tabular_dummy.py
+++ b/pyout/tabular_dummy.py
@@ -46,12 +46,12 @@ class Tabular(interface.Writer):
 
     def __init__(self, columns=None, style=None, stream=None,
                  interactive=None, mode=None, continue_on_failure=True,
-                 max_workers=None):
+                 wait_for_top=3, max_workers=None):
         super(Tabular, self).__init__(
             columns, style, stream=stream,
             interactive=interactive, mode=mode,
             continue_on_failure=continue_on_failure,
-            max_workers=max_workers)
+            wait_for_top=wait_for_top, max_workers=max_workers)
         streamer = NoUpdateTerminalStream(
             stream=stream, interactive=interactive)
         super(Tabular, self)._init(style, streamer)

--- a/pyout/tabular_dummy.py
+++ b/pyout/tabular_dummy.py
@@ -45,10 +45,12 @@ class Tabular(interface.Writer):
     """
 
     def __init__(self, columns=None, style=None, stream=None,
-                 interactive=None, mode=None, max_workers=None):
+                 interactive=None, mode=None, continue_on_failure=True,
+                 max_workers=None):
         super(Tabular, self).__init__(
             columns, style, stream=stream,
             interactive=interactive, mode=mode,
+            continue_on_failure=continue_on_failure,
             max_workers=max_workers)
         streamer = NoUpdateTerminalStream(
             stream=stream, interactive=interactive)

--- a/pyout/tests/test_interface.py
+++ b/pyout/tests/test_interface.py
@@ -1,0 +1,26 @@
+import pytest
+
+pytest.importorskip("blessings")
+
+import inspect
+
+from pyout.interface import Stream
+from pyout.interface import Writer
+from pyout.tabular import Tabular
+from pyout.tabular import TerminalStream
+from pyout.tabular_dummy import NoUpdateTerminalStream
+from pyout.tabular_dummy import Tabular as DummyTabular
+
+
+@pytest.mark.parametrize("writer",
+                         [Tabular, DummyTabular],
+                         ids=["tabular", "dummy"])
+def test_writer_children_match_signature(writer):
+    assert inspect.signature(writer) == inspect.signature(Writer)
+
+
+@pytest.mark.parametrize("stream",
+                         [TerminalStream, NoUpdateTerminalStream],
+                         ids=["terminal", "noupdate"])
+def test_stream_children_match_signature(stream):
+    assert inspect.signature(stream) == inspect.signature(Stream)

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -895,7 +895,10 @@ class Delayed(object):
         """
         while True:
             if self.now:
-                return self.value
+                value = self.value
+                if callable(value):
+                    value = value()
+                return value
 
 
 @pytest.mark.timeout(10)

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -375,6 +375,22 @@ def test_tabular_non_hashable_id_error():
         out({"name": "foo", "status": [0, 1]})
 
 
+def test_tabular_content_get_idkey():
+    out = Tabular(["first", "last", "status"])
+    out.ids = ["first", "last"]
+    data = [{"first": "foo", "last": "bert", "status": "ok"},
+            {"first": "foo", "last": "zoo", "status": "bad"},
+            {"first": "bar", "last": "t", "status": "unknown"}]
+    for row in data:
+        out(row)
+
+    for idx, key in enumerate([("foo", "bert"), ("foo", "zoo"), ("bar", "t")]):
+        assert out._content.get_idkey(idx) == key
+
+    with pytest.raises(IndexError):
+        out._content.get_idkey(4)
+
+
 def test_tabular_write_lookup_color():
     out = Tabular(style={"name": {"width": 3},
                          "status": {"color": {"lookup": {"BAD": "red"}},

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -900,6 +900,10 @@ class Delayed(object):
                     value = value()
                 return value
 
+    def gen(self):
+        value = self.run()
+        yield value
+
 
 @pytest.mark.timeout(10)
 def test_tabular_write_callable_values():

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -1231,9 +1231,8 @@ def test_tabular_shrinking_summary():
 
 
 def test_tabular_mode_invalid():
-    out = Tabular(["name", "status"])
     with pytest.raises(ValueError):
-        out.mode = "unknown"
+        Tabular(["name", "status"], mode="unknown")
 
 
 def test_tabular_mode_default():
@@ -1247,8 +1246,7 @@ def test_tabular_mode_default():
         for row in data:
             out0(row)
 
-    out1 = Tabular()
-    out1.mode = "update"
+    out1 = Tabular(mode="update")
     with out1:
         for row in data:
             out1(row)
@@ -1256,24 +1254,15 @@ def test_tabular_mode_default():
     assert out0.stdout == out1.stdout
 
 
-def test_tabular_mode_after_write():
-    out = Tabular(["name", "status"])
-    out(["foo", "ok"])
-    with pytest.raises(ValueError):
-        out.mode = "final"
-
-
 def test_tabular_mode_update_noninteractive():
     out = Tabular(["name", "status"], interactive=False)
-    assert out.mode == "final"
-    with pytest.raises(ValueError):
-        out.mode = "update"
+    assert out._mode == "final"
 
 
 def test_tabular_mode_incremental():
     out = Tabular(["name", "status"],
-                  style={"status": {"aggregate": len}})
-    out.mode = "incremental"
+                  style={"status": {"aggregate": len}},
+                  mode="incremental")
 
     with out:
         out({"name": "foo", "status": "ok"})
@@ -1288,8 +1277,7 @@ def test_tabular_mode_incremental():
 
 
 def test_tabular_mode_final():
-    out = Tabular(["name", "status"])
-    out.mode = "final"
+    out = Tabular(["name", "status"], mode="final")
 
     with out:
         out({"name": "foo", "status": "unknown"})
@@ -1302,8 +1290,8 @@ def test_tabular_mode_final():
 
 def test_tabular_mode_final_summary():
     out = Tabular(["name", "status"],
-                  style={"status": {"aggregate": len}})
-    out.mode = "final"
+                  style={"status": {"aggregate": len}},
+                  mode="final")
 
     with out:
         out({"name": "foo", "status": "unknown"})

--- a/pyout/tests/test_tabular_dummy.py
+++ b/pyout/tests/test_tabular_dummy.py
@@ -36,6 +36,5 @@ def test_tabular_basic():
 
 
 def test_tabular_update_mode_disallowed():
-    out = Tabular(["name", "status"])
     with pytest.raises(ValueError):
-        out.mode = "update"
+        Tabular(["name", "status"], mode="update")


### PR DESCRIPTION
This is a work-in-progress series that switches from using `multiprocessing.dummy.Pool` to `concurrent.futures.ThreadPoolExecutor`.  The main motivation is to improve the exception reporting for asynchronous row values (#94).