### PR TITLE
RF: dissolve 'validation' extra_requires - move jsonschema into core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
 from setuptools import setup
 
 requires = {
-    "core": ["blessings; sys_platform != 'win32'"],
+    "core": [
+        "blessings; sys_platform != 'win32'",
+        "jsonschema>=3.0.0",
+    ],
     "tests": ["pytest", "pytest-timeout", "mock"],
-    "validation": ["jsonschema>=3.0.0"],
 }
 
 requires["full"] = list(requires.values())


### PR DESCRIPTION
validation is triggered unconditionally. With outdated jsonschema, validation
could crash (see https://github.com/pyout/pyout/pull/90#issuecomment-544163911)
entire process.  So it is necessary to guarantee that default installation has
compatible jsonschema
