### PR TITLE
BF: do not assume that column is present in hidden

### DIFF
--- a/pyout/common.py
+++ b/pyout/common.py
@@ -622,7 +622,7 @@ class StyleFields(object):
         if can_unhide:
             for c in row:
                 val = row[c]
-                if hidden[c] == "if_missing" and not isinstance(val, Nothing):
+                if hidden.get(c) == "if_missing" and not isinstance(val, Nothing):
                     lgr.debug("Unhiding column %r after encountering %r",
                               c, val)
                     hidden[c] = False


### PR DESCRIPTION
quick and dirty patch I had to do to avoid
```shell
$> dandi ls -F path,nd_types ../nwb-datasets/nwb_test_data/v2.0.0/test_C*
--------------------------------------------------------------------------
[[30834,1],0]: A high-performance Open MPI point-to-point messaging module
was unable to find any relevant network interfaces:

Module: OpenFabrics (openib)
  Host: lena

Another transport will be used instead, although this may result in
lower performance.

NOTE: You can disable this warning by setting the MCA parameter
btl_base_warn_component_unused to 0.
--------------------------------------------------------------------------
PATH                                                                     ND_TYPES
../nwb-datasets/nwb_test_data/v2.0.0/test_Clustering.nwb                         
../nwb-datasets/nwb_test_data/v2.0.0/test_ClusterWaveforms.nwb                   
../nwb-datasets/nwb_test_data/v2.0.0/test_CurrentClampSeries.nwb                 
../nwb-datasets/nwb_test_data/v2.0.0/test_CurrentClampStimulusSeries.nwb         
2020-01-08 23:06:05,711 [   ERROR] exception calling callback for <Future at 0x7f8d540179d0 state=finished returned dict>
Traceback (most recent call last):
  File "/usr/lib/python3.7/concurrent/futures/_base.py", line 324, in _invoke_callbacks
    callback(self)
  File "/home/yoh/proj/repronim/pyout/pyout/interface.py", line 471, in callback
    id_vals, cols, future.result())
  File "/home/yoh/proj/repronim/pyout/pyout/interface.py", line 94, in wrapped
    return method(self, *args, **kwds)
  File "/home/yoh/proj/repronim/pyout/pyout/interface.py", line 421, in _write_async_result
    self._write(result)
  File "/home/yoh/proj/repronim/pyout/pyout/interface.py", line 339, in _write
    self._write_fn(row, style)
  File "/home/yoh/proj/repronim/pyout/pyout/interface.py", line 354, in _write_update
    content, status, summary = self._content.update(row, style)
  File "/home/yoh/proj/repronim/pyout/pyout/common.py", line 858, in update
    content, status = super(ContentWithSummary, self).update(row, style)
  File "/home/yoh/proj/repronim/pyout/pyout/common.py", line 825, in update
    line, adjusted = self.fields.render(row, style)
  File "/home/yoh/proj/repronim/pyout/pyout/common.py", line 625, in render
    if hidden[c] == "if_missing" and not isinstance(val, Nothing):
2020-01-08 23:06:05,898 [   ERROR] exception calling callback for <Future at 0x7f8d540244d0 state=finished returned dict>
Traceback (most recent call last):
  File "/usr/lib/python3.7/concurrent/futures/_base.py", line 324, in _invoke_callbacks
    callback(self)
  File "/home/yoh/proj/repronim/pyout/pyout/interface.py", line 471, in callback
    id_vals, cols, future.result())
  File "/home/yoh/proj/repronim/pyout/pyout/interface.py", line 94, in wrapped
    return method(self, *args, **kwds)
  File "/home/yoh/proj/repronim/pyout/pyout/interface.py", line 421, in _write_async_result
    self._write(result)
  File "/home/yoh/proj/repronim/pyout/pyout/interface.py", line 339, in _write
    self._write_fn(row, style)
  File "/home/yoh/proj/repronim/pyout/pyout/interface.py", line 354, in _write_update
    content, status, summary = self._content.update(row, style)
  File "/home/yoh/proj/repronim/pyout/pyout/common.py", line 858, in update
    content, status = super(ContentWithSummary, self).update(row, style)
  File "/home/yoh/proj/repronim/pyout/pyout/common.py", line 825, in update
    line, adjusted = self.fields.render(row, style)
  File "/home/yoh/proj/repronim/pyout/pyout/common.py", line 625, in render
    if hidden[c] == "if_missing" and not isinstance(val, Nothing):
KeyError: 'nwb_version'
```
(dandi ls code for that yet to be provided, but probably if remove `,nd_types` in above, would achieve the same)
