### PR TITLE
Avoid race in keyboard interrupt tests

### DIFF
--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -1229,6 +1229,10 @@ def test_tabular_write_callable_kb_interrupt_in_exit():
         with out:
             out(OrderedDict([("name", "foo"), ("status", delay0.run)]))
             out(OrderedDict([("name", "bar"), ("status", delay1.run)]))
+            # Hold up until output from the first callable has been
+            # written.
+            while "v0" not in out.stdout:
+                time.sleep(0.1)
             raise KeyboardInterrupt
 
     thread = threading.Thread(target=run_tabular)
@@ -1252,6 +1256,13 @@ def test_tabular_write_callable_kb_interrupt_during_wait():
 
     def run_tabular():
         def raise_kbint():
+            # Hold up until output from the callables has been
+            # written.
+            while True:
+                stdout = out.stdout
+                if "v0" and "v1" in stdout:
+                    break
+                time.sleep(0.1)
             raise KeyboardInterrupt
 
         out.wait = raise_kbint


### PR DESCRIPTION
test_tabular_write_callable_kb_interrupt_in_exit is failing in some
outside builds (gh-103) in a way that hasn't occurred on Travis or for
me locally.  The failure is due to the stream lacking the output from
the asynchronous callables.

There is a race between writing the callable output when the Delayed()
callable is marked as ready and raising the artificial
KeyboardInterrupt exception.  I can trigger this locally when I slow
down the callable by adding a sleep (say 3 seconds) right before
Delayed().run() returns.

Avoid this race by not raising the KeyboardInterrupt until the delayed
output has reached its destination.  Don't worry about hanging because
these test are already marked with pytest.mark.timeout().

Closes #103.