### PR TITLE
Prevent unknown columns from coming in via asynchronous callables

### DIFF
--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -127,6 +127,20 @@ def test_tabular_write_data_as_list():
     assert_eq_repr(out.stdout, expected)
 
 
+@pytest.mark.parametrize("data_type", ["dict", "seq", "obj"])
+def test_tabular_write_unknown_column(data_type):
+    if data_type == "dict":
+        row = {"name": "a", "unk": "unk"}
+    elif data_type == "seq":
+        row = ["a", "unk"]
+    else:
+        row = AttrData(name="a", unk="unk")
+
+    out = Tabular(columns=["name"])
+    out(row)
+    assert_eq_repr(out.stdout, "a\n")
+
+
 def test_tabular_width_no_style():
     out = Tabular(["name"])
     out(["a" * 105])

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -1055,6 +1055,28 @@ def test_tabular_write_callable_unknown_column():
 
 
 @pytest.mark.timeout(10)
+def test_tabular_write_callable_unknown_column_multikey():
+    delay = Delayed({"status": "done", "unk": "unk_value"})
+    out = Tabular(["name", "status"])
+    with out:
+        out({"name": "foo", ("status", "unk"): delay.run})
+        delay.now = True
+    assert_contains_nc(out.stdout.splitlines(),
+                       "foo done")
+
+
+@pytest.mark.timeout(10)
+def test_tabular_write_callable_only_unknown_columns_multikey():
+    def fail():
+        raise AssertionError("Should not be called")
+
+    out = Tabular(["name", "status"])
+    with out:
+        out({"name": "foo", ("unk0", "unk1"): fail})
+    assert out.stdout.strip() == "foo"
+
+
+@pytest.mark.timeout(10)
 def test_tabular_write_callable_sneaky_unknown_column():
     delay = Delayed({"status": "ok", "unk": "unk_value"})
     out = Tabular(["name", "status"])

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -1044,6 +1044,38 @@ def test_tabular_write_callable_values_multi_return():
 
 
 @pytest.mark.timeout(10)
+def test_tabular_write_callable_unknown_column():
+    delay = Delayed({"status": "done", "unk": "unkval"})
+    out = Tabular(["name", "status"])
+    with out:
+        out({"name": "foo", "status": delay.run})
+        delay.now = True
+    assert_contains_nc(out.stdout.splitlines(),
+                       "foo done")
+
+
+@pytest.mark.timeout(10)
+def test_tabular_write_callable_sneaky_unknown_column():
+    delay = Delayed({"status": "ok", "unk": "unk_value"})
+    out = Tabular(["name", "status"])
+    with out:
+        out({"name": "foo", "status": delay.run})
+        delay.now = True
+    assert_contains_nc(out.stdout.splitlines(),
+                       "foo ok")
+
+
+@pytest.mark.timeout(10)
+def test_tabular_write_callable_returns_only_unknown():
+    delay = Delayed({"unk": "unk_value"})
+    out = Tabular(["name", "status"])
+    with out:
+        out({"name": "foo", "status": delay.run})
+        delay.now = True
+    assert out.stdout.strip() == "foo"
+
+
+@pytest.mark.timeout(10)
 @pytest.mark.parametrize("nrows", [20, 21])
 def test_tabular_callback_to_offscreen_row(nrows):
     delay = Delayed("OK")


### PR DESCRIPTION
This series implements the second option discussed at gh-102:

> As discussed before (e.g., gh-49 and gh-86), pyout relies on knowing all the columns up front, so I think this spot is right to assume that a column name is in `hidden`. I'd say it's upstream code that should do one of the following if asynchronous function provides an unknown columns: (1) error or (2) filter it out. I'm leaning toward no. 2 because I'm not sure there's anything gained by being stricter here. I'll look into where I think the best spot to do this is.

The second commit in particular resolves the specific failure from gh-102.
