### PR TITLE
Support expanding set of known columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- The list of known columns is now expanded dynamically if a row
+  passed to `Tabular` contains a new column, provided that either the
+  row is a dictionary or a value of the row is a callable that returns
+  a dictionary.
 
 ## [0.5.1] - 2020-04-08
 


### PR DESCRIPTION
Lift the requirement that the set of columns be known up front.
Ideally this should be done in a single spot, because scattering
dict.get() and other handling throughout the code will be hard to
reason about and is likely to be a source of bugs.

Get close to that goal by making StyleFields.render() raise an
exception when it encounters an unknown column and then have _write(),
which importantly is working with an acquired lock, do the necessary
re-initializations.

Adjust some upstream spots to let unknown columns through, including
reverting the filtering of unknown columns from c21579bb (Merge pull
request #108 from kyleam/filter-unknown-cols, 2020-06-01).  Having the
upstream code itself register the new columns doesn't work well
because new columns can come in through plain values passed to
Tabular.__call__() and through the return values of asynchronous
functions.

Closes #49.