### PR TITLE
interface: Try to coerce undocumented types to a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Before the last release, `Tabular` worked when given a tuple for
+  `columns` instead of one of the documented types (a list of strings
+  or an `OrderedDict`).  This previous behavior has been restored.
 
 ## [0.6.0] - 2020-08-03
 

--- a/pyout/interface.py
+++ b/pyout/interface.py
@@ -105,7 +105,11 @@ class Writer(object):
     def __init__(self, columns=None, style=None, stream=None,
                  interactive=None, mode=None, continue_on_failure=True,
                  wait_for_top=3, max_workers=None):
-        self._columns = columns
+        if columns and not isinstance(columns, (list, OrderedDict)):
+            self._columns = list(columns)
+        else:
+            self._columns = columns or None
+
         self._ids = None
 
         self._last_content_len = 0

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -67,6 +67,22 @@ def test_tabular_write_missing_column_missing_text():
     assert_eq_repr(out.stdout, "solo -\n")
 
 
+def test_tabular_write_columns_as_tuple():
+    out = Tabular(columns=("name", "status"), style={"header_": {}})
+    out({"name": "foo", "status": "ok"})
+    lines = out.stdout.splitlines()
+    assert_contains_nc(lines, "name status", "foo  ok    ")
+
+
+@pytest.mark.parametrize("columns", [False, [], tuple()],
+                         ids=["False", "empty list", "empty tuple"])
+def test_tabular_write_columns_falsey(columns):
+    out = Tabular(columns=columns, style={"header_": {}})
+    out({"name": "foo", "status": "ok"})
+    lines = out.stdout.splitlines()
+    assert_contains_nc(lines, "name status", "foo  ok    ")
+
+
 def test_tabular_write_list_value():
     out = Tabular(columns=["name", "status"])
     out({"name": "foo", "status": [0, 1]})


### PR DESCRIPTION
Tabular's `columns` parameter is documented as accepting a list of str
or an OrderedDict, but, until 373f664e (Support expanding set of known
columns, 2020-06-10), it also happened to tolerate tuples and probably
some other sequences.  At least one spot in third-party code already
passes a tuple, so make this work again.

Closes #110.