### PR TITLE
Bump minimum Python version to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 sudo: false
 
 python:
-  - 3.4
+  - 3.6
   - 3.8
 
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Python 3.6 or later is now required.
+
 - `Tabular` now tries to detect changes in the terminal's width and
    height.
 

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ should be usable in its current form, it may change in substantial
 ways that break backward compatibility, and many aspects currently
 lack polish and documentation.
 
-``pyout`` requires Python 3 (>= 3.4).  It is developed and tested in
+``pyout`` requires Python 3 (>= 3.6).  It is developed and tested in
 GNU/Linux environments and is expected to work in macOS environments
 as well.  There is currently very limited Windows support.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,10 +6,10 @@ build: false
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.1"
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.8"
       PYTHON_ARCH: "32"
-      MINICONDA: C:\Miniconda35
+      MINICONDA: C:\Miniconda36
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     license="MIT",
     url="https://github.com/pyout/pyout.git",
     packages=["pyout", "pyout.tests"],
+    python_requires=">=3.6",
     tests_require=requires["tests"],
     setup_requires=["pytest-runner"],
     install_requires=requires["core"],


### PR DESCRIPTION
The latest Travis build with Python 3.4 failed with

    pyrsistent requires Python '>=3.5' but the running Python is 3.4.8

Rather than try to pin versions to work around this, bump pyout's
minimum Python version to 3.6.  This matches the minimum of dandi-cli,
the main project that uses pyout.

Ref: https://travis-ci.org/github/pyout/pyout/jobs/728570815#L228