### PR TITLE
field: Match newlines with Flanks regexp

### DIFF
--- a/pyout/field.py
+++ b/pyout/field.py
@@ -456,7 +456,7 @@ class Flanks(object):
     """A pair of processors that split and rejoin flanking whitespace.
     """
 
-    flank_re = re.compile(r"(\s*)(.*\S)(\s*)\Z")
+    flank_re = re.compile(r"(\s*)(.*\S)(\s*)\Z", flags=re.DOTALL)
 
     def __init__(self):
         self.left, self.right = None, None

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -367,6 +367,13 @@ def test_tabular_write_style_flanking():
     assert_eq_repr(out.stdout, expected)
 
 
+def test_tabular_write_style_flanking_newlines():
+    out = Tabular(columns=["name", "status"])
+    out({"name": "foo", "status": "a\nb"})
+    # The flanking regexp should match even if the field has new lines.
+    assert out.stdout.strip() == "foo a\nb"
+
+
 def test_tabular_write_align():
     out = Tabular(["name"],
                   style={"name": {"align": "right", "width": 10}})


### PR DESCRIPTION
The Flanks class chops off flanking whitespace before applying the
other post-format processors and then adds back the whitespace
afterward.  This prevents, for example, underlining the flanking
whitespace.

The regexp that matches the flanking whitespace should always match,
but it doesn't account for the fact that the caller could pass in a
value with newlines.  A field with newlines will break pyout in other
ways (e.g., line updates), so we may want to consider escaping values
to prevent this.  But either way, a value with newlines shouldn't
trigger a failure in the Flanks processor, so adjust the regexp to
allow for newlines.

Closes #104.
Closes #115.