### PR TITLE
Add python 3.9 into matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 python:
   - 3.6
   - 3.8
+  - 3.9
 
 install:
   - pip install -U pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 python:
   - 3.6
   - 3.8
-  - 3.9
+  - 3.9-dev
 
 install:
   - pip install -U pip


### PR DESCRIPTION
conda started to build for 3.9 but there are some inconsistent results
https://github.com/conda-forge/pyout-feedstock/pull/7

wanted to see if travis already has 3.9, how well it would work