### PR TITLE
interface: Don't try to clear summary more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- For a table with a summary, encountering an unknown row led to lines
+  before the first line of the table being overwritten.
 
 ## [0.7.0] - 2020-11-13
 

--- a/pyout/interface.py
+++ b/pyout/interface.py
@@ -358,15 +358,15 @@ class Writer(object):
             except UnknownColumns as exc:
                 self._columns.extend(exc.unknown_columns)
                 self._init_prewrite()
-                self._write_fn(row, style)
+                self._write_fn(row, style, redo=True)
 
     def _get_last_summary_length(self):
         last_summary = self._last_summary
         return len(last_summary.splitlines()) if last_summary else 0
 
-    def _write_update(self, row, style=None):
+    def _write_update(self, row, style=None, redo=False):
         last_summary_len = self._get_last_summary_length()
-        if last_summary_len > 0:
+        if last_summary_len > 0 and not redo:
             # Clear the summary because 1) it has very likely changed, 2)
             # it makes the counting for row updates simpler, 3) and it is
             # possible for the summary lines to shrink.
@@ -409,7 +409,7 @@ class Writer(object):
         self._last_content_len = len(self._content)
         self._last_summary = summary
 
-    def _write_incremental(self, row, style=None):
+    def _write_incremental(self, row, style=None, redo=False):
         content, status, summary = self._content.update(row, style)
         if isinstance(status, int):
             lgr.debug("Duplicating line %d with %r", status, row)
@@ -418,7 +418,7 @@ class Writer(object):
         self._stream.write(content)
         self._last_summary = summary
 
-    def _write_final(self, row, style=None):
+    def _write_final(self, row, style=None, redo=False):
         _, _, summary = self._content.update(row, style)
         self._last_summary = summary
 

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -1758,6 +1758,19 @@ def test_tabular_shrinking_summary():
     assert len([ln for ln in lines if ln.startswith(expected)]) == 1
 
 
+def test_tabular_summary_avoid_repeated_clear():
+    out = Tabular(style={"name": {"aggregate": len}})
+    out(OrderedDict([("name", "foo")]))
+    out(OrderedDict([("name", "bar"),
+                     ("new", "col")]))
+    # The new column requires a rewrite, but the summary has already been
+    # removed, so that shouldn't lead to an additional move-up and clear.
+    lines = out.stdout.splitlines()
+    assert_eq_repr(lines[-3],  # -1: summary, -2: bar
+                   unicode_cap("cuu1") + unicode_cap("ed") +
+                   unicode_cap("cuu1") + "foo    ")
+
+
 def test_tabular_mode_invalid():
     with pytest.raises(ValueError):
         Tabular(["name", "status"], mode="unknown")


### PR DESCRIPTION
If a table has a summary, _write_update() clears it.  However, the
write function is called a second time if an unknown column is
encountered.  In that case, there's no summary to clear, leading to
the counts being off and lines upstream of the first row being
overwritten.

Extend the write functions with a parameter to enable distinguishing
the first and second call so that write functions can avoid any logic
that shouldn't be repeated.

Closes #128.