### PR TITLE
Declare JSON schema as following Draft 7

### DIFF
--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 import jsonschema
 
 schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         # Plain style elements
         "align": {


### PR DESCRIPTION
Fixes #130.

The JSON Schema used by pyout currently lacks a `"$schema"` key declaring what version of the JSON Schema standard it uses.  This causes the jsonschema library to validate it using the latest released draft; this draft changed in version 4.0 of the library from Draft 7 to Draft 2020-12, hence the failures reported in #130.

This PR adds an explicit `"$schema"` key to pyout's JSON schema that declares it as following JSON Schema Draft 7.