### PR TITLE
Stop using `setup.py test`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-source = pyout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,17 +21,16 @@ jobs:
           - '3.10'
           - '3.11'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - name: Install dependencies
       run: |
         pip install -U pip
-        pip install codecov
-        pip install .[full]
+        pip install codecov coverage tox
     - name: Run tests
-      run: coverage run setup.py test && coverage xml
+      run: tox -e py && coverage xml
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,8 +27,8 @@ install:
   - "conda create -q -n test-environment python=%PYTHON_VERSION%"
   - activate test-environment
   - python -c "import sys; print(sys.path)"
-  - pip install codecov
-  - pip install -e ".[full]"
+  - pip install codecov pytest pytest-timeout
+  - pip install -e .
 
 test_script:
   - coverage run -m pytest --doctest-ignore-import-errors -rs && coverage xml

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = --doctest-modules

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[aliases]
-test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,5 @@
 from setuptools import setup
 
-requires = {
-    "core": [
-        # formergly blessings were used, code allows for either
-        # see https://github.com/pyout/pyout/issues/136
-        "blessed; sys_platform != 'win32'",
-        "jsonschema>=3.0.0",
-    ],
-    "tests": ["pytest", "pytest-timeout"],
-}
-
-requires["full"] = list(requires.values())
-
 setup(
     name="pyout",
     version="0.7.3",
@@ -22,10 +10,10 @@ setup(
     url="https://github.com/pyout/pyout.git",
     packages=["pyout", "pyout.tests"],
     python_requires=">=3.7",
-    tests_require=requires["tests"],
-    setup_requires=["pytest-runner"],
-    install_requires=requires["core"],
-    extras_require=requires,
+    install_requires=[
+        "blessed; sys_platform != 'win32'",
+        "jsonschema>=3.0.0",
+    ],
     long_description=open("README.rst").read(),
     classifiers=[
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,19 @@
 [tox]
-envlist = py37
+envlist = py3
 
 [testenv]
 commands =
-     coverage run setup.py test
+     coverage erase
+     coverage run -m pytest {posargs} pyout
      coverage report -m
 
 deps =
      coverage
      pytest
+     pytest-timeout
+
+[pytest]
+addopts = --doctest-modules
+
+[coverage:run]
+source = pyout


### PR DESCRIPTION
`setup.py test` is deprecated.  Use `tox` instead.

Also update & improve some other infrastructure elements.