### PR TITLE
OPT: cache validation of styles

### DIFF
--- a/pyout/elements.py
+++ b/pyout/elements.py
@@ -310,12 +310,21 @@ class StrHasher():
         Custom LRU cache decorator that allows for a custom hasher function.
         """
         def decorator(func):
-            @functools.wraps(func)
-            @cls._to
             @functools.lru_cache(maxsize=maxsize)
             @cls._from
-            def cached_func(*args, **kwargs):
+            def lru_cached_func(*args, **kwargs):
                 return func(*args, **kwargs)
+
+            # Interface cache operations
+            cached_func = functools.wraps(func)(
+                cls._to(
+                    lru_cached_func
+                )
+            )
+            for op in dir(lru_cached_func):
+                if op.startswith('cache_'):
+                   setattr(cached_func, op,
+                    getattr(lru_cached_func, op))
             return cached_func
         return decorator
 

--- a/pyout/tests/conftest.py
+++ b/pyout/tests/conftest.py
@@ -1,2 +1,10 @@
 import pytest
 pytest.register_assert_rewrite("pyout.tests.utils")
+
+from pyout.elements import validate
+
+
+@pytest.fixture(autouse=True)
+def cache_clear():
+    yield
+    validate.cache_clear()


### PR DESCRIPTION
While troubleshooting slow "dandi download" we saw that considerable amount of time is spent on jsonschema validation (and logging, not considered here). See https://github.com/dandi/dandi-cli/issues/1549

It is happening since we be providing styling per each row, which might differ for summary line etc. And we might be re-validating over and over again. The obvious solution, without trying to fix logic upstairs, is to use @lru_cache.  But it could be not used as-is since style is a dict (mutable), nested, and can have function callbacks.  Conversion of such style to `str` is relatively fast and should be good enough for jsonschema validation.  Unfortunately an initial attempt to just wrap into some "Hashable" instance lead to jsonschema pukes.

So I decided to wrap/unwrap the value and use has of md5 over str representation. Seems to work nicely and I hope it would eliminate some elevate performance issue a little (it is not an ultimate solution in original issue -- likely need to "slow down" records reporting).

May be @jwodder sees a better solution?