### PR TITLE
Run GH CI testing also on macos and fix up tests for potential stalling in Delayed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,13 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
         python:
           - 3.9
           - '3.10'

--- a/pyout/tests/test_tabular.py
+++ b/pyout/tests/test_tabular.py
@@ -1046,7 +1046,12 @@ class Delayed(object):
     def run(self):
         """Return `value` once `now` is true.
         """
+        t0 = time.time()
         while True:
+            if time.time() - t0 > 10:
+                sys.stderr.write(f"Testing helper Delayed({self.value}) was never properly terminated")
+                traceback.print_stack()
+                raise RuntimeError("Timeout")
             if self.now:
                 value = self.value
                 if callable(value):
@@ -1431,6 +1436,7 @@ def test_tabular_write_callable_kb_interrupt_in_exit():
     assert_contains_nc(stdout.splitlines(),
                        "foo v0",
                        "bar   ")
+    delay1.now = True
 
 
 @pytest.mark.timeout(10)
@@ -1524,6 +1530,7 @@ def test_tabular_cancel_in_exit():
         assert "v0" in stdout
         assert "v1" not in stdout
         assert "v2" not in stdout
+    delay_2.now = True
 
 
 @pytest.mark.timeout(10)

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,15 @@ envlist = py3
 
 [testenv]
 commands =
-     coverage erase
-     coverage run -m pytest {posargs} pyout
-     coverage report -m
+    coverage erase
+    PYTEST_DEBUG=1 python -m pytest -s -v --cov=pyout {posargs} pyout
+    coverage combine
+    coverage report -m
 
 deps =
      coverage
      pytest
+     pytest-cov
      pytest-timeout
 
 [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,10 @@
 envlist = py3
 
 [testenv]
+setenv =
+    PYTEST_DEBUG = 1
 commands =
-    coverage erase
-    PYTEST_DEBUG=1 python -m pytest -s -v --cov=pyout {posargs} pyout
-    coverage combine
-    coverage report -m
-
+    python -m pytest -s -v --cov=pyout {posargs} pyout
 deps =
      coverage
      pytest


### PR DESCRIPTION
Extract from 
- #47

to add testing into matrix only on macos, leaving Windows to deal with in that PR