### PR TITLE
Add type annotations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,11 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
+        toxenv:
+          - py
         include:
-          - python-version: '3.9'
+          - python: '3.9'
             toxenv: typing
-            os: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python }}
@@ -37,7 +38,7 @@ jobs:
         pip install -U pip
         pip install codecov coverage tox
     - name: Run tests
-      run: tox -e py && coverage xml
+      run: tox -e ${{ matrix.toxenv }} && coverage xml
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v5
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,10 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
+        include:
+          - python-version: '3.9'
+            toxenv: typing
+            os: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python }}

--- a/pyout/common.py
+++ b/pyout/common.py
@@ -717,10 +717,10 @@ class Content(object):
 
     Parameters
     ----------
-    fields : StyleField instance
+    fields : StyleFields instance
     """
 
-    def __init__(self, fields):
+    def __init__(self, fields: StyleFields):
         self.fields = fields
         self.summary = None
 
@@ -840,7 +840,7 @@ class Content(object):
                    .format(idx, len(self._idkey_to_idx)))
             raise IndexError(msg) from None
 
-    def update(self, row, style):
+    def update(self, row, style) -> tuple[str, str | int]:
         """Modify the content.
 
         Parameters
@@ -858,13 +858,13 @@ class Content(object):
         A tuple of (content, status), where status is 'append', an integer, or
         'repaint'.
 
-          * append: the only change in the content is the addition of a line,
+          * 'append': the only change in the content is the addition of a line,
             and the returned content will consist of just this line.
 
           * an integer, N: the Nth line of the output needs to be update, and
             the returned content will consist of just this line.
 
-          * repaint: all lines need to be updated, and the returned content
+          * 'repaint': all lines need to be updated, and the returned content
             will consist of all the lines.
         """
         called_before = bool(self)
@@ -925,14 +925,14 @@ class ContentWithSummary(Content):
 
     def __init__(self, fields):
         super(ContentWithSummary, self).__init__(fields)
-        self.summary = None
+        self.summary: Summary | None = None
 
-    def init_columns(self, columns, ids, table_width=None):
+    def init_columns(self, columns, ids, table_width=None) -> None:
         super(ContentWithSummary, self).init_columns(
             columns, ids, table_width=table_width)
         self.summary = Summary(self.fields.style)
 
-    def update(self, row, style):
+    def update(self, row, style) -> tuple[str, str | int, str | None]:
         lgr.log(9, "Updating with .summary set to %s", self.summary)
         content, status = super(ContentWithSummary, self).update(row, style)
         if self.summary:

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -487,7 +487,7 @@ class PlainProcessors(StyleProcessors):
     """Ignore color, bold, or underline styling.
     """
 
-    style_types = {}
+    style_types = OrderedDict()
 
 
 class TermProcessors(StyleProcessors):

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -12,7 +12,7 @@ import os
 try:
     from blessed import Terminal
 except ImportError:
-    from blessings import Terminal
+    from blessings import Terminal  # type: ignore
 
 from pyout import interface
 from pyout.field import TermProcessors

--- a/pyout/tests/terminal.py
+++ b/pyout/tests/terminal.py
@@ -11,7 +11,7 @@ import re
 try:
     import blessed as bls
 except ImportError:
-    import blessings as bls
+    import blessings as bls  # type: ignore
 
 from pyout.tests.utils import assert_contains
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3
+envlist = typing, py3
 
 [testenv]
 commands =
@@ -11,6 +11,14 @@ deps =
      coverage
      pytest
      pytest-timeout
+
+[testenv:typing]
+deps =
+    mypy
+    {[testenv]deps}
+    types-jsonschema
+commands =
+    mypy pyout
 
 [pytest]
 addopts = --doctest-modules --timeout=120

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     {[testenv]deps}
     types-jsonschema
 commands =
-    mypy pyout
+    mypy --strict pyout
 
 [pytest]
 addopts = --doctest-modules --timeout=120


### PR DESCRIPTION
A start on https://github.com/pyout/pyout/issues/142

Currently there are no type annotations in the actual code, but thats ok if we run mypy in permissive mode. 

