### PR TITLE
Ignore ANSI colors when determining col width

### DIFF
--- a/pyout/common.py
+++ b/pyout/common.py
@@ -14,11 +14,12 @@ from collections.abc import Sequence
 from functools import partial
 import inspect
 from logging import getLogger
+import re
 
 from pyout import elements
 from pyout.field import Field
 from pyout.field import Nothing
-from pyout.truncate import Truncater
+from pyout.truncate import Truncater, strip_ansi_codes
 from pyout.summary import Summary
 
 lgr = getLogger(__name__)
@@ -502,7 +503,7 @@ class StyleFields(object):
             else:
                 value = row[column]
             value = str(value)
-            value_width = len(value)
+            value_width = len(strip_ansi_codes(value))
             wmax = autowidth_columns[column]["max"]
             wmin = autowidth_columns[column]["min"]
             max_seen = max(value_width, field.width)

--- a/pyout/field.py
+++ b/pyout/field.py
@@ -9,6 +9,7 @@ import re
 import sys
 
 from pyout.elements import value_type
+from pyout.truncate import strip_ansi_codes
 
 lgr = getLogger(__name__)
 
@@ -118,7 +119,10 @@ class Field(object):
     def _format(self, _, result):
         """Wrap format call as a two-argument processor function.
         """
-        return self._fmt.format(str(result))
+        stripped = strip_ansi_codes(str(result))
+        uncolored = self._fmt.format(stripped)
+        colored = uncolored.replace(stripped, str(result))
+        return colored
 
     def __call__(self, value, keys=None, exclude_post=False):
         """Render `value` by feeding it through the processors.

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -6,6 +6,7 @@ This module defines the Tabular entry point.
 from contextlib import contextmanager
 from logging import getLogger
 import os
+import re
 
 # Eventually we may want to retire blessings:
 # https://github.com/pyout/pyout/issues/136

--- a/pyout/tabular.py
+++ b/pyout/tabular.py
@@ -6,7 +6,6 @@ This module defines the Tabular entry point.
 from contextlib import contextmanager
 from logging import getLogger
 import os
-import re
 
 # Eventually we may want to retire blessings:
 # https://github.com/pyout/pyout/issues/136

--- a/pyout/truncate.py
+++ b/pyout/truncate.py
@@ -1,9 +1,18 @@
 """Processor for field value truncation.
 """
+import re
+
+def strip_ansi_codes(s: str) -> str:
+    ansi_escape = re.compile(
+        r'(?:\x1B[@-Z\\-_]|'   # ESC followed by any one character in this range
+        r'\x1B\[[0-?]*[ -/]*[@-~])'  # or ESC [ followed by 0 or more codes and a final command
+    )
+    return ansi_escape.sub('', s)
+
 
 
 def _truncate_right(value, length, marker):
-    if len(value) <= length:
+    if len(strip_ansi_codes(value)) <= length:
         short = value
     elif marker:
         nchars_free = length - len(marker)
@@ -53,7 +62,7 @@ def _splice(value, n):
 
 
 def _truncate_center(value, length, marker):
-    value_len = len(value)
+    value_len = len(strip_ansi_codes(value))
     if value_len <= length:
         return value
 


### PR DESCRIPTION
Fixes: https://github.com/pyout/pyout/issues/152

This probably needs some work to be "complete" but I've solved it for my use case.

![image](https://github.com/user-attachments/assets/41977934-d570-4acf-8554-0afce9639913)

TODO
- [ ] Needs tests
- [ ] benchmark w/duct
- [ ] More hand-testing outside of `tabular` 
- [ ] how to handles `style` including colors? 
- [ ] I didnt spot a utils to put the ansi stripper-- it doesnt really belong in truncater IMO.
- [ ] verify the regex (verbatim and unreviewed from chatgpt)