### PR TITLE
First get content for summary and only then clear prior one

### DIFF
--- a/pyout/common.py
+++ b/pyout/common.py
@@ -861,7 +861,7 @@ class Content(object):
           * append: the only change in the content is the addition of a line,
             and the returned content will consist of just this line.
 
-          * an integer, N: the Nth line of the output needs to be update, and
+          * an integer, N: the Nth line of the output needs to be updated, and
             the returned content will consist of just this line.
 
           * repaint: all lines need to be updated, and the returned content

--- a/pyout/interface.py
+++ b/pyout/interface.py
@@ -366,6 +366,8 @@ class Writer(object):
 
     def _write_update(self, row, style=None, redo=False):
         last_summary_len = self._get_last_summary_length()
+        content, status, summary = self._content.update(row, style)
+
         if last_summary_len > 0 and not redo:
             # Clear the summary because 1) it has very likely changed, 2)
             # it makes the counting for row updates simpler, 3) and it is
@@ -373,7 +375,6 @@ class Writer(object):
             lgr.debug("Clearing summary of %d line(s)", last_summary_len)
             self._stream.clear_last_lines(last_summary_len)
 
-        content, status, summary = self._content.update(row, style)
 
         single_row_updated = False
         if isinstance(status, int):

--- a/pyout/interface.py
+++ b/pyout/interface.py
@@ -358,17 +358,18 @@ class Writer(object):
             except UnknownColumns as exc:
                 self._columns.extend(exc.unknown_columns)
                 self._init_prewrite()
-                self._write_fn(row, style, redo=True)
+                self._write_fn(row, style)
 
     def _get_last_summary_length(self):
         last_summary = self._last_summary
         return len(last_summary.splitlines()) if last_summary else 0
 
-    def _write_update(self, row, style=None, redo=False):
+    def _write_update(self, row, style=None):
         last_summary_len = self._get_last_summary_length()
+
         content, status, summary = self._content.update(row, style)
 
-        if last_summary_len > 0 and not redo:
+        if last_summary_len > 0:
             # Clear the summary because 1) it has very likely changed, 2)
             # it makes the counting for row updates simpler, 3) and it is
             # possible for the summary lines to shrink.
@@ -410,7 +411,7 @@ class Writer(object):
         self._last_content_len = len(self._content)
         self._last_summary = summary
 
-    def _write_incremental(self, row, style=None, redo=False):
+    def _write_incremental(self, row, style=None):
         content, status, summary = self._content.update(row, style)
         if isinstance(status, int):
             lgr.debug("Duplicating line %d with %r", status, row)
@@ -419,7 +420,7 @@ class Writer(object):
         self._stream.write(content)
         self._last_summary = summary
 
-    def _write_final(self, row, style=None, redo=False):
+    def _write_final(self, row, style=None):
         _, _, summary = self._content.update(row, style)
         self._last_summary = summary
 


### PR DESCRIPTION
Getting summary might take time. If we wipe out prior one first, in effect we seems to not show it for long whenever most of the time we deal with computing the summary. As a result we cause it to blink severily.

By first getting the summary content while prior one is still displayed, and only then wiping it out, we seems to avoid this issue and summary remains visible nicely without blinking.

Closes #154